### PR TITLE
Add unified StSLib integration and plugin exposure

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -22,3 +22,11 @@ plugins do not incur repeated reflection overhead.
 ## LimeWire decryption pipeline
 
 Build a Python implementation of the LimeWire content decrypter so that the encrypted jars downloaded during bundling can be unwrapped automatically. Usage: mirror the `GE#getContentItemDecryptionKeys` flow in Python, deriving AES keys from the passphrase and decrypting the AES-CTR stream into usable game jars.
+
+## StSLib feature matrix generation
+
+Generate runtime documentation for every exposed StSLib hook, action and interface by introspecting the loaded JVM classes. Usage: extend ``UnifiedSpireAPI`` with an ``introspect()`` helper that emits Markdown files inside ``research/`` summarising constructor signatures and expected usage patterns. This keeps the Python façade aligned with future StSLib releases.
+
+## Unified keyword profiles
+
+Allow describing complex keyword setups declaratively via JSON/YAML manifest files. Usage: add ``UnifiedSpireAPI.load_keywords(path: Path)`` that consumes manifests, registers keywords, and applies card field defaults to reduce boilerplate for large mods.

--- a/modules/basemod_wrapper/__init__.py
+++ b/modules/basemod_wrapper/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Dict, Iterable, Optional, Sequence
 
 from .loader import ensure_basemod_environment, ensure_jpype
 from .project import BundleOptions, ModProject, compileandbundle, create_project
@@ -32,15 +32,28 @@ class BaseModEnvironment:
         "com.megacrit.cardcrawl",
         "com.badlogic.gdx",
         "com.evacipated.cardcrawl.modthespire",
+        "com.evacipated.cardcrawl.mod.stslib",
     )
 
     def __init__(self, base_dir: Path | None = None) -> None:
         self.base_dir = base_dir or Path(__file__).resolve().parent
-        ensure_basemod_environment(self.base_dir)
+        self._jars = ensure_basemod_environment(self.base_dir)
         self._packages: dict[str, JavaPackageWrapper] = {}
 
         for package in self.DEFAULT_PACKAGES:
             self.package(package)
+
+    @property
+    def dependency_jars(self) -> Dict[str, Path]:
+        """Return the resolved dependency jar mapping."""
+
+        return dict(self._jars)
+
+    @property
+    def classpath(self) -> Sequence[Path]:
+        """Return the default classpath used for the JVM."""
+
+        return tuple(self._jars.values())
 
     def package(self, name: str) -> JavaPackageWrapper:
         """Return a :class:`JavaPackageWrapper` for ``name``."""
@@ -49,10 +62,257 @@ class BaseModEnvironment:
             self._packages[name] = create_package_wrapper(name)
         return self._packages[name]
 
+    def resolve(self, dotted_path: str) -> Any:
+        """Resolve ``dotted_path`` against known packages and classes."""
+
+        segments = dotted_path.split(".")
+        for split in range(len(segments), 0, -1):
+            package_name = ".".join(segments[:split])
+            try:
+                target = self.package(package_name)
+            except Exception:
+                continue
+            value: Any = target
+            for attr in segments[split:]:
+                value = getattr(value, attr)
+            return value
+        raise AttributeError(f"Unable to resolve '{dotted_path}'.")
+
+    def default_bundle_options(
+        self,
+        *,
+        python_source: Path,
+        assets_source: Path,
+        output_directory: Path,
+        version: str = "0.1.0",
+        sts_version: str = "2020-12-01",
+        mts_version: str = "3.30.1",
+        dependencies: Optional[Sequence[str]] = None,
+        additional_classpath: Optional[Sequence[Path]] = None,
+    ) -> BundleOptions:
+        """Produce a :class:`BundleOptions` instance with sensible defaults."""
+
+        classpath = list(self.classpath)
+        if additional_classpath:
+            classpath.extend(additional_classpath)
+        resolved_dependencies = tuple(dependencies or ("basemod", "stslib"))
+        return BundleOptions(
+            java_classpath=tuple(classpath),
+            python_source=python_source,
+            assets_source=assets_source,
+            output_directory=output_directory,
+            version=version,
+            sts_version=sts_version,
+            mts_version=mts_version,
+            dependencies=resolved_dependencies,
+        )
+
     # Convenience attribute access -------------------------------------------------
     def __getattr__(self, item: str) -> JavaPackageWrapper:
         return self.package(item)
 
+
+class UnifiedSpireAPI:
+    """High level façade over BaseMod and StSLib functionality."""
+
+    _ACTION_MAP: Dict[str, str] = {
+        "addtemporaryhp": "com.evacipated.cardcrawl.mod.stslib.actions.tempHp.AddTemporaryHPAction",
+        "removealltemporaryhp": "com.evacipated.cardcrawl.mod.stslib.actions.tempHp.RemoveAllTemporaryHPAction",
+        "autoplaycard": "com.evacipated.cardcrawl.mod.stslib.actions.common.AutoplayCardAction",
+        "damagecallback": "com.evacipated.cardcrawl.mod.stslib.actions.common.DamageCallbackAction",
+        "fetch": "com.evacipated.cardcrawl.mod.stslib.actions.common.FetchAction",
+        "movecards": "com.evacipated.cardcrawl.mod.stslib.actions.common.MoveCardsAction",
+        "multigroupmove": "com.evacipated.cardcrawl.mod.stslib.actions.common.MultiGroupMoveAction",
+        "multigroupselect": "com.evacipated.cardcrawl.mod.stslib.actions.common.MultiGroupSelectAction",
+        "refund": "com.evacipated.cardcrawl.mod.stslib.actions.common.RefundAction",
+        "selectcards": "com.evacipated.cardcrawl.mod.stslib.actions.common.SelectCardsAction",
+        "selectcardscentered": "com.evacipated.cardcrawl.mod.stslib.actions.common.SelectCardsCenteredAction",
+        "selectcardsinhand": "com.evacipated.cardcrawl.mod.stslib.actions.common.SelectCardsInHandAction",
+        "stunmonster": "com.evacipated.cardcrawl.mod.stslib.actions.common.StunMonsterAction",
+        "evokespecificorb": "com.evacipated.cardcrawl.mod.stslib.actions.defect.EvokeSpecificOrbAction",
+        "triggerpassive": "com.evacipated.cardcrawl.mod.stslib.actions.defect.TriggerPassiveAction",
+        "gaincustomblock": "com.evacipated.cardcrawl.mod.stslib.actions.common.GainCustomBlockAction",
+        "modifyexhaustive": "com.evacipated.cardcrawl.mod.stslib.actions.common.ModifyExhaustiveAction",
+        "allenemyapplypower": "com.evacipated.cardcrawl.mod.stslib.actions.common.AllEnemyApplyPowerAction",
+    }
+
+    _BOOLEAN_KEYWORDS: Dict[str, str] = {
+        "autoplay": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.AutoplayField.autoplay",
+        "retain": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.AlwaysRetainField.alwaysRetain",
+        "icons": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.CommonKeywordIconsField.useIcons",
+        "fleeting": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.FleetingField.fleeting",
+        "grave": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.GraveField.grave",
+        "purge": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PurgeField.purge",
+        "snecko": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.SneckoField.snecko",
+        "soulbound": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.SoulboundField.soulbound",
+    }
+
+    _NUMERIC_KEYWORDS: Dict[str, Dict[str, str]] = {
+        "exhaustive": {
+            "setter": "com.evacipated.cardcrawl.mod.stslib.variables.ExhaustiveVariable.setBaseValue",
+            "upgrader": "com.evacipated.cardcrawl.mod.stslib.variables.ExhaustiveVariable.upgrade",
+        },
+        "persist": {
+            "setter": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PersistFields.setBaseValue",
+            "upgrader": "com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PersistFields.upgrade",
+        },
+        "refund": {
+            "setter": "com.evacipated.cardcrawl.mod.stslib.variables.RefundVariable.setBaseValue",
+            "upgrader": "com.evacipated.cardcrawl.mod.stslib.variables.RefundVariable.upgrade",
+        },
+    }
+
+    def __init__(self, environment: BaseModEnvironment) -> None:
+        self._env = environment
+        self.basemod = environment.package("basemod")
+        self.stslib = environment.package("com.evacipated.cardcrawl.mod.stslib")
+        self.cardcrawl = environment.package("com.megacrit.cardcrawl")
+        self.modthespire = environment.package("com.evacipated.cardcrawl.modthespire")
+        self.libgdx = environment.package("com.badlogic.gdx")
+        self.damage_modifiers = environment.package(
+            "com.evacipated.cardcrawl.mod.stslib.damagemods"
+        )
+        self.block_modifiers = environment.package(
+            "com.evacipated.cardcrawl.mod.stslib.blockmods"
+        )
+        self.icons = environment.package(
+            "com.evacipated.cardcrawl.mod.stslib.icons"
+        )
+
+    def __getattr__(self, item: str) -> Any:
+        for namespace in (self.basemod, self.stslib):
+            try:
+                return getattr(namespace, item)
+            except AttributeError:
+                continue
+        raise AttributeError(item)
+
+    # ------------------------------------------------------------------
+    # Actions and helpers
+    # ------------------------------------------------------------------
+    def action(self, name: str) -> Any:
+        key = name.replace(" ", "").replace("_", "").lower()
+        try:
+            path = self._ACTION_MAP[key]
+        except KeyError as exc:  # pragma: no cover - defensive path
+            raise KeyError(f"Unknown StSLib action '{name}'.") from exc
+        return self._env.resolve(path)
+
+    # ------------------------------------------------------------------
+    # Keyword helpers
+    # ------------------------------------------------------------------
+    def apply_keyword(
+        self,
+        card: Any,
+        keyword: str,
+        *,
+        value: Any = True,
+        amount: Optional[int] = None,
+        upgrade: Optional[int] = None,
+    ) -> None:
+        key = keyword.replace(" ", "").lower()
+        if key in self._BOOLEAN_KEYWORDS:
+            field = self._env.resolve(self._BOOLEAN_KEYWORDS[key])
+            field.set(card, bool(value))
+            return
+        if key in self._NUMERIC_KEYWORDS:
+            if amount is None:
+                raise ValueError(f"Keyword '{keyword}' requires an 'amount'.")
+            mapping = self._NUMERIC_KEYWORDS[key]
+            setter = self._env.resolve(mapping["setter"])
+            setter(card, int(amount))
+            if upgrade:
+                upgrader = self._env.resolve(mapping["upgrader"])
+                upgrader(card, int(upgrade))
+            return
+        raise KeyError(f"Unknown keyword '{keyword}'.")
+
+    def keyword_fields(self) -> Dict[str, str]:
+        """Expose the keyword map so callers can introspect support."""
+
+        data: Dict[str, str] = {}
+        data.update(self._BOOLEAN_KEYWORDS)
+        for key, mapping in self._NUMERIC_KEYWORDS.items():
+            data[key] = mapping["setter"]
+        return data
+
+    # ------------------------------------------------------------------
+    # Modifier helpers
+    # ------------------------------------------------------------------
+    def add_damage_modifier(self, owner: Any, modifier: Any) -> None:
+        manager = self.damage_modifiers.DamageModifierManager
+        manager.addModifier(owner, modifier)
+
+    def add_block_modifier(self, owner: Any, modifier: Any) -> None:
+        manager = self.block_modifiers.BlockModifierManager
+        manager.addModifier(owner, modifier)
+
+    def register_custom_icon(self, icon: Any) -> None:
+        helper = self.icons.CustomIconHelper
+        helper.addCustomIcon(icon)
+
+    # ------------------------------------------------------------------
+    # Keyword registration
+    # ------------------------------------------------------------------
+    def register_keyword(
+        self,
+        mod_id: str,
+        keyword_id: str,
+        names: Sequence[str],
+        description: str,
+        *,
+        proper_name: Optional[str] = None,
+        color: Optional[Sequence[float]] = None,
+    ) -> Any:
+        Keyword = self.stslib.Keyword
+        keyword_obj = Keyword()
+        keyword_obj.ID = keyword_id
+        keyword_obj.NAMES = list(names)
+        keyword_obj.DESCRIPTION = description
+        if proper_name:
+            keyword_obj.PROPER_NAME = proper_name
+        if color:
+            color_info = None
+            for attr in ("KeywordInfo", "KeywordColorInfo"):
+                try:
+                    color_info = getattr(self.basemod.helpers, attr)
+                    break
+                except AttributeError:
+                    continue
+            if color_info:
+                keyword_obj.COLOR = color_info(*color)
+        base_mod = self.basemod.BaseMod
+        try:
+            base_mod.addKeyword(mod_id, keyword_obj)
+        except TypeError:
+            base_mod.addKeyword(mod_id, keyword_obj.PROPER_NAME or keyword_obj.NAMES[0], keyword_obj.NAMES, keyword_obj.DESCRIPTION)
+        return keyword_obj
+
+    # ------------------------------------------------------------------
+    # Bundling helpers
+    # ------------------------------------------------------------------
+    def bundle_options(
+        self,
+        *,
+        python_source: Path,
+        assets_source: Path,
+        output_directory: Path,
+        version: str = "0.1.0",
+        sts_version: str = "2020-12-01",
+        mts_version: str = "3.30.1",
+        dependencies: Optional[Sequence[str]] = None,
+        additional_classpath: Optional[Sequence[Path]] = None,
+    ) -> BundleOptions:
+        return self._env.default_bundle_options(
+            python_source=python_source,
+            assets_source=assets_source,
+            output_directory=output_directory,
+            version=version,
+            sts_version=sts_version,
+            mts_version=mts_version,
+            dependencies=dependencies,
+            additional_classpath=additional_classpath,
+        )
 
 # Eagerly create the default environment and expose frequently used packages.
 _ENVIRONMENT = BaseModEnvironment()
@@ -62,6 +322,8 @@ modthespire: JavaPackageWrapper = _ENVIRONMENT.package(
     "com.evacipated.cardcrawl.modthespire"
 )
 libgdx: JavaPackageWrapper = _ENVIRONMENT.package("com.badlogic.gdx")
+stslib: JavaPackageWrapper = _ENVIRONMENT.package("com.evacipated.cardcrawl.mod.stslib")
+spire: UnifiedSpireAPI = UnifiedSpireAPI(_ENVIRONMENT)
 
 # Share everything with the plugin manager.
 PLUGIN_MANAGER.expose("basemod_environment", _ENVIRONMENT)
@@ -69,18 +331,26 @@ PLUGIN_MANAGER.expose("basemod", basemod)
 PLUGIN_MANAGER.expose("cardcrawl", cardcrawl)
 PLUGIN_MANAGER.expose("modthespire", modthespire)
 PLUGIN_MANAGER.expose("libgdx", libgdx)
+PLUGIN_MANAGER.expose("stslib", stslib)
+PLUGIN_MANAGER.expose("spire", spire)
+PLUGIN_MANAGER.expose("basemod_dependency_jars", _ENVIRONMENT.dependency_jars)
+PLUGIN_MANAGER.expose("basemod_classpath", _ENVIRONMENT.classpath)
 PLUGIN_MANAGER.expose("create_project", create_project)
 PLUGIN_MANAGER.expose("compileandbundle", compileandbundle)
 PLUGIN_MANAGER.expose("ModProject", ModProject)
 PLUGIN_MANAGER.expose("BundleOptions", BundleOptions)
+PLUGIN_MANAGER.expose("default_bundle_options", _ENVIRONMENT.default_bundle_options)
 PLUGIN_MANAGER.expose_module("modules.basemod_wrapper", alias="basemod_wrapper")
 
 __all__ = [
     "BaseModEnvironment",
+    "UnifiedSpireAPI",
     "basemod",
     "cardcrawl",
     "modthespire",
     "libgdx",
+    "stslib",
+    "spire",
     "ModProject",
     "BundleOptions",
     "create_project",

--- a/modules/basemod_wrapper/project.py
+++ b/modules/basemod_wrapper/project.py
@@ -173,6 +173,7 @@ class BundleOptions:
     version: str = "0.1.0"
     sts_version: str = "2020-12-01"
     mts_version: str = "3.30.1"
+    dependencies: Sequence[str] = ("basemod", "stslib")
 
 
 class ModProject:
@@ -407,7 +408,7 @@ class ModProject:
             "version": options.version,
             "sts_version": options.sts_version,
             "mts_version": options.mts_version,
-            "dependencies": ["basemod"],
+            "dependencies": list(dict.fromkeys(options.dependencies)),
         }
         return json.dumps(manifest, indent=2)
 
@@ -426,7 +427,8 @@ class ModProject:
 
     @staticmethod
     def _build_classpath(entries: Sequence[Path]) -> str:
-        return os.pathsep.join(str(entry) for entry in entries)
+        ordered = list(dict.fromkeys(entries))
+        return os.pathsep.join(str(entry) for entry in ordered)
 
 
 def create_project(mod_id: str, name: str, author: str, description: str, version: str = "0.1.0") -> ModProject:

--- a/research/basemod_BaseMod_source.java
+++ b/research/basemod_BaseMod_source.java
@@ -1,0 +1,3 @@
+// Retrieval note:
+// Attempted to download BaseMod.java from https://raw.githubusercontent.com/daviscook477/BaseMod/master/src/main/java/basemod/BaseMod.java
+// GitHub responded with HTTP 404 on this date, so no source snapshot was captured.

--- a/research/basemod_keyword_color_info.java
+++ b/research/basemod_keyword_color_info.java
@@ -1,0 +1,3 @@
+// Retrieval note:
+// Attempted to download KeywordColorInfo.java from https://raw.githubusercontent.com/daviscook477/BaseMod/master/src/main/java/basemod/helpers/KeywordColorInfo.java
+// GitHub responded with HTTP 404 on this date, so no source snapshot was captured.

--- a/research/stslib_Actions.md
+++ b/research/stslib_Actions.md
@@ -1,0 +1,14 @@
+Class Name | Description
+--- | ---
+StunMonsterAction | Stuns a monster so it can't act for a turn.
+FetchAction | Move card(s) from some pile to the hand.
+MoveCardsAction | Move card(s) from some pile to another pile.
+AddTemporaryHPAction | Add Temporary HP to the player or a monster.
+RemoveAllTemporaryHPAction | Removes all Temporary HP from the player or a monster.
+EvokeSpecificOrbAction | Evokes a given orb.
+TriggerPassiveAction | Triggers the passive ability of a given orb.
+SelectCardsAction | Select cards in a grid to do what you want.
+SelectCardsInHandAction | Select cards in hand. Visually same as Armaments, True Grit etc.
+MultiGroupSelectAction | Select cards from multiple groups (hand, draw, discard). Opens a modified grid select that shows what groups cards are in.
+MultiGroupMoveAction | Select cards from multiple groups (hand, draw, discard) to move to another group.
+DamageCallbackAction | Allows to easily make effects that deal with "unblocked damage dealt", eg. Wallop.

--- a/research/stslib_AlwaysRetainField.java
+++ b/research/stslib_AlwaysRetainField.java
@@ -1,0 +1,32 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class AlwaysRetainField
+{
+    public static SpireField<Boolean> alwaysRetain = new RetainField(() -> false);
+
+    // This is done so `retain` can be set automatically when this field is set in a card's constructor
+    private static class RetainField extends SpireField<Boolean>
+    {
+        RetainField(DefaultValue<Boolean> defaultValue)
+        {
+            super(defaultValue);
+        }
+
+        @Override
+        public void set(Object __intance, Boolean value)
+        {
+            super.set(__intance, value);
+            if (value && __intance instanceof AbstractCard) {
+                ((AbstractCard)__intance).retain = true;
+            }
+        }
+    }
+}

--- a/research/stslib_AutoplayField.java
+++ b/research/stslib_AutoplayField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class AutoplayField
+{
+    public static SpireField<Boolean> autoplay = new SpireField<>(() -> false);
+}

--- a/research/stslib_Block-Modifiers.md
+++ b/research/stslib_Block-Modifiers.md
@@ -1,0 +1,59 @@
+## Making Block Modifiers
+To make a block modifier, simply make a new class that extends AbstractBlockModifier and override the methods you wish to use. Your block mod always overrides getName and getDescription so the Block Manager can display your Block successfully. Whenever a creature gains block that has been augmented with a block modifier, it will render an extra icon next to the normal Block symbol that you can hover for the name and description of the block mod.
+
+### Example Block Modifier
+This is an example of a Block Type that only decreases by 5 at the start of your turn, but when it does decrease this way, you gain Vigor equal to the amount lost
+```Java
+public class SpicyBlock extends AbstractBlockModifier {
+
+    public static final String ID = YourModID.makeID("SpicyBlock");
+    public final CardStrings cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
+
+    public SpicyBlock() {}
+
+    @Override
+    public int amountLostAtStartOfTurn() {
+        return 5;
+    }
+
+    @Override
+    public void onStartOfTurnBlockLoss(int blockLost) {
+        this.addToBot(new ApplyPowerAction(owner, owner, new VigorPower(owner, blockLost)));
+    }
+
+    @Override
+    public String getName() {
+        return cardStrings.NAME;
+    }
+
+    @Override
+    public String getDescription() {
+        return cardStrings.DESCRIPTION;
+    }
+}
+
+```
+
+## Using Custom Block Types
+Just like damage mods, block mods autobind by default when applied to a card with a GainBlockAction in it's `use()` method. Manual binding can still be performed via a new GainCustomBlockAction that has been created. This action either takes a card that has block mods bound to it via BlockModifierManager, or a BlockModContainer which can be used by anything else.
+```Java
+    public SnowFort() {
+        super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET, AbstractVivianDamageModifier.TipType.DAMAGE_AND_BLOCK);
+        baseBlock = block = BLOCK;
+        BlockModifierManager.addModifier(this, new IceBlock());
+    }
+
+    // Actions the card should do.
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        //This auto binds if IceBlock has autobinding set to true, but gives normal block if autobinding is not set
+        this.addToBot(new GainBlockAction(p, block));
+        //This manually binds the block mods stored in the card. Using a BlockModContainer in place of `this` is also acceptable and is how to apply block mods via relics, orbs, etc.
+        this.addToBot(new GainCustomBlockAction(this, p, block));
+    }
+```
+
+The Block Manager will then add your block to the list of block types for the owner. If the list is not empty, Block Manager will render UI icon next to their Block amount that shows the list of active blocks and their order. The Block Manager uses a **First In -> Last Out** system. If you add customs blocks 1, 2, 3 in that order, then when taking damage, block 3 will be the *first* to be reduced.
+
+### Using Block Modifiers on Cards
+Block Modifiers used innately on cards should override `isInherent` to return true, or they will end up duplicated.

--- a/research/stslib_Cards.md
+++ b/research/stslib_Cards.md
@@ -1,0 +1,145 @@
+# Branching Upgrades on Cards
+An interface that has to be implemented on the card that is supposed to have a branching upgrade. This allows the card to have two distinct upgrade paths which the player can choose between when smithing.
+
+Implementation example:
+```Java
+public class CoolCard extends CustomCard implements BranchingUpgradesCard
+{
+    ...
+  @Override
+  public void upgrade() {
+    if (!this.upgraded) {
+      upgradeName();
+      if (isBranchUpgrade()) {
+        branchUpgrade();
+      } else {
+        baseUpgrade();
+      } 
+    } 
+  }
+
+  public void baseUpgrade() {
+    ...
+  }
+  
+  public void branchUpgrade() {
+    ...
+  }
+}
+```
+
+# Common Keyword Icons
+Boolean SpireField on cards that, if set to true, will render small icons representing certain common keywords in the top-right of the card. 
+If the icons are present, the tooltips for the card are automatically added. This allows the card text to not include them and saving some space.
+
+The following keywords can be replaced by an icon:
+
+Innate, Ethereal, Retain, Purge, and Exhaust.
+
+Implementation example:
+```Java
+public class NoKeywordTextCard extends CustomCard
+{
+    public NoKeywordTextCard () {
+        ...
+        CommonKeywordIconsField.useIcons.set(this, true);
+    }
+}
+```
+
+# Spawn Modification Cards
+This is an interface you can implement on cards that allows you to fully control how and if a card will be spawned and what happens if it does.
+  
+This interface has 3 methods that achieve this:  
+
+## canSpawn  
+When the card implementing this interface is rolled, this method gets called before it is added to the ArrayList containing the cards that will be in the card reward and before the code checks for duplicates.  
+  
+Parameters:   
+**currentRewardCards** ArrayList\<AbstractCard\>   
+List of the cards that were already rolled excluding the card that calls this method. This is not guaranteed to contain all cards of the reward, it may even be empty at the time.  
+  
+Return: boolean  
+Allows you to either let the card spawn by returning **true** or rolling a new card if you return **false**. By default, this method always returns **true**.  
+  
+Example:  
+The card has a 50% chance to actually spawn if rolled and you can only have one instance of it in your deck.
+```Java
+public class TestCard extends CustomCard implements SpawnModificationCard {
+    public TestCard(...)
+    ...
+
+    @Override
+    public boolean canSpawn(ArrayList<AbstractCard> currentRewardCards) {
+        //50% chance to not be allowed to spawn.
+        if(AbstractDungeon.cardRng.randomBoolean()) {
+            return false;
+        }
+        
+        //Player can't already have the card.
+        for(AbstractCard c : AbstractDungeon.player.masterDeck.group) {
+            if (c.cardID.equals(this.cardID)) {
+                return false;
+            }
+        }
+        
+        //Card will spawn.
+        return true;
+    }
+}
+```
+
+## replaceWith  
+This method is called if **canSpawn** returns **true** and allows you to replace the rolled card with a new card instance that will be checked against the currentRewardCards to see if it's a duplicate or not. By default, the card doesn't get modified.  
+  
+Parameters:  
+**currentRewardCards** ArrayList\<AbstractCard\>   
+List of the cards that were already rolled excluding the card that calls this method. This is not guaranteed to contain all cards of the reward, it may even be empty at the time.  
+  
+Return: AbstractCard  
+The instance of the card that gets added to the list. 
+  
+Example:
+If the player has a rare card in their deck, the card reward will contain a curse instead.
+```Java
+public class TestCard extends CustomCard implements SpawnModificationCard {
+    public TestCard(...)
+    ...
+
+    @Override
+    public AbstractCard replaceWith(ArrayList<AbstractCard> currentRewardCards) {
+        for(AbstractCard c : AbstractDungeon.player.masterDeck.group) {
+            if(c.rarity == CardRarity.RARE) {
+                return new Pain();
+            }
+        }
+        return this;
+    }
+}
+```  
+  
+## onRewardListCreated  
+This method allows you to make final modifications to any card in the list right before the card reward is created.  
+**Note**: I advise against replacing cards at this stage because **AbstractRelic:onPreviewObtainCard** and upgrade chances have already been calculated before this point.
+  
+Parameter:  
+**rewardCards** ArrayList\<AbstractCard\>  
+The list of cards that will be in the card reward.  
+  
+Example:  
+If this card is in a card reward, all other cards will be upgraded.  
+```Java
+public class TestCard extends CustomCard implements SpawnModificationCard {
+    public TestCard(...)
+    ...
+
+    @Override
+    public void onRewardListCreated(ArrayList<AbstractCard> rewardCards) {
+        for(AbstractCard c : rewardCards) {
+            if (c != this && c.canUpgrade()) {
+                c.upgrade();
+            }
+        }
+    }
+}
+```

--- a/research/stslib_Colored-Damage-Numbers.md
+++ b/research/stslib_Colored-Damage-Numbers.md
@@ -1,0 +1,1 @@
+404: Not Found

--- a/research/stslib_CommonKeywordIconsField.java
+++ b/research/stslib_CommonKeywordIconsField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        clz = AbstractCard.class,
+        method=SpirePatch.CLASS
+)
+public class CommonKeywordIconsField {
+    public static SpireField<Boolean> useIcons = new SpireField<>(() -> false);
+}

--- a/research/stslib_Custom-Targeting.md
+++ b/research/stslib_Custom-Targeting.md
@@ -1,0 +1,63 @@
+In some cases, you may want a card that you can aim (targeting arrow) at something other than an enemy.
+This is what custom targeting is for.
+
+Three things are required.
+1. A TargetingHandler
+2. A CardTarget enum
+3. Registering your custom targeting
+
+For an example, this is an implementation of targeting the player or an enemy, which you can use if it happens to be what you need.
+https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java
+
+At the top, you can see
+```
+    @SpireEnum
+    public static AbstractCard.CardTarget SELF_OR_ENEMY;
+```
+This is the `CardTarget` for this handler.
+
+To properly create a [TargetingHandler](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/TargetingHandler.java), you need at minimum the following:
+
+1. Extend the `TargetingHandler` class with an appropriate type parameter depending on what you want to target. In the [example](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L20), this is `AbstractCreature`, as both the player and enemies extend this class.
+
+2. Define the following methods:
+```
+    public abstract void updateHovered(); //Update/check what valid target is currently hovered
+    public abstract ? getHovered(); //Returns what is currently hovered (should just be null if none). ? is whatever the class you're targeting is.
+    public abstract void clearHovered(); //Clear current target when leaving targeting mode
+    public abstract boolean hasTarget(); //Whether a valid target is hovered
+```
+
+Everything else is optional. Some of it for keyboard input support, and some of it for visuals.
+
+In Slay the Spire, targeting works in two steps.
+First, while you're dragging the card and aiming the arrow, it tracks what target you're currently hovering.
+Then, when you release, the card is queued with that currently hovered target.
+
+So, the first step is to create a tracking variable in your class that extends `TargetingHandler` to store the currently hovered target.
+You can see this [here](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L28) in the example.
+
+Next, is the `updateHovered` method. This is the method that actually will check the possible targets to see what's currently hovered.
+In [this](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L36) case, the targets are the player or an enemy, so it checks those and stores the first one that's hovered.
+
+Then there's the [getHovered](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L57), [clearHovered](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L62), and [hasTarget](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/cards/targeting/SelfOrEnemyTargeting.java#L31) methods. These are relatively self-explanatory, just performing basic actions on the hovered target variable.
+
+Then the last step: registering it. This can be done at basically any time, but `postInitialize` is a good option.
+You can see this [here](https://github.com/kiooeht/StSLib/blob/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/StSLib.java#L72); register your `CardTarget` and an instance of your `TargetHandler`.
+
+## Using Custom Targeting
+
+First, it would need to use the `CardTarget`. Set the card's CardTarget to your defined enum like you would with any other targeting option.
+Then, in the `use` method, access where you've stored the card's target. In the case of `SelfOrEnemyTargeting`, you would set the card's target to `SelfOrEnemyTargeting.SELF_OR_ENEMY`, and the card's `use` might look something like
+```
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        AbstractCreature target = SelfOrEnemyTargeting.getTarget(this);
+
+        if (target == null)
+            target = AbstractDungeon.player;
+
+        addToBot(new GainBlockAction(target, p, this.block));
+    }
+```
+
+You should always include a null check for safety. It's hard to guarantee that the card won't get played through some unusual method that doesn't target it, such as Mayhem, which only assigns a random monster target. Depending on your setup, you could have `getTarget` return a random valid target if it would return null.

--- a/research/stslib_Damage-Modifiers.md
+++ b/research/stslib_Damage-Modifiers.md
@@ -1,0 +1,380 @@
+## Making Damage Modifiers
+Damage modifiers allow you to control how damage from cards, monsters, relics, etc. works during all steps of damage dealing. In simple cases, it allows easy access to piercing damage that bypasses block while still triggering powers like Thorns. In more advanced cases it can trigger certain powers and even use Wallop like followup effects to gain Block or apply debuffs equal to damage dealt.
+
+To make a damage modifier, simply create a new class that extends AbstractDamageModifier and override the functions you wish to use. By default, damage mods will **automatically bind** when applied to a card, requiring no special functions to work in the cards `use()` method. This functionality can be overridden if you wish to manually control when damage mods activate (an example of this is shown further below). 
+
+Damage mods are not limited to cards, as they can also be used by DamageModContainers, an object that holds any number of damage modifiers and a reference to the object using the damage modifiers. DamgageModContainers allow things like relics, monsters, orbs, and powers to apply damage mods to the damage they deal. When using DamageModContainers, manual damage binding must be performed (an example of this is also shown further below).
+
+
+### Example Modifier
+This modifier heals the damage dealer equal to unblocked damage dealt. If it is applied to a card it will also add a tooltip and a descriptor to the card.
+```Java
+public class LeechDamage extends AbstractDamageModifier {
+    public static final String ID = YourModID.makeID("LeechDamage");
+    public final CardStrings cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
+
+    TooltipInfo leechTooltip = null;
+
+    public LeechDamage() {}
+
+    //This hook grabs the lastDamageTaken once it is updated upon attacking the monster.
+    //This lets us heal the attacker equal to the damage that was actually dealt to the target
+    @Override
+    public void onLastDamageTakenUpdate(DamageInfo info, int lastDamageTaken, int overkillAmount, AbstractCreature targetHit) {
+        if (lastDamageTaken > 0) {
+            this.addToBot(new HealAction(info.owner, info.owner, lastDamageTaken));
+        }
+    }
+
+    //This hook allows up to add a custom tooltip to any cards it is added to.
+    //In this case, we are using cardstrings to get the localized data
+    @Override
+    public TooltipInfo getCustomTooltip() {
+        if (leechTooltip == null) {
+            leechTooltip = new TooltipInfo(cardStrings.DESCRIPTION, cardStrings.EXTENDED_DESCRIPTION[0]);
+        }
+        return leechTooltip;
+    }
+
+    //This allows us to add an stslib descriptor to the card
+    // If it was originally an Attack, it will now read "Attack | Leech"
+    @Override
+    public String getCardDescriptor() {
+        return cardStrings.NAME;
+    }
+
+    //Overriding this to true tells us that this damage mod is considered part of the card and not just something added on to the card later.
+    //If you ever add a damage modifier during the initialization of a card, it should be inherent. 
+    public boolean isInherent() {
+        return true;
+    }
+
+}
+```
+**Accompanying Json** - Using an icon is optional
+```Json
+  "YourModID:LeechDamage": {
+    "NAME": "Leech",
+    "DESCRIPTION": "Leech Damage [YourModID:DrainIcon]",
+    "EXTENDED_DESCRIPTION": ["Heals the attacker equal to unblocked damage dealt."]
+  }
+```
+
+## Using Damage Modifiers on Cards
+
+To use a damage modifier that is always active on a card, the syntax is very similar to adding a card modifier: we use DamageModifierManager and add whatever modifier we want to `this`, being the card we are initializing. For these examples, we will assume that the damage mods have already been created. Modifiers used innately on cards should override `isInherent` to return true, or they will end up duplicated.
+```Java
+    public ShadeFist() {
+        super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
+        baseDamage = damage = DAMAGE;
+        DamageModifierManager.addModifier(this, new FireDamage());
+    }
+```
+As cards have automatic binding by default, dealing damage in the cards `use()` method will now grab all damage modifiers that have been applied to the card and use them if this functionality has not been overwritten.
+```Java
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        //This hit will automatically bind as it is in the cards use() method
+        this.addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
+    }
+```
+Should you disable automatic binding for full control over when damage mods are applied, manual binding is required. The following example showcases how to manually bind damage mods if the target has Vulnerable, but not bind any mods if the target does not have Vulnerable.
+```Java
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        if (m.hasPower(VulnerablePower.POWER_ID)) {
+            //Bind the damage mods if the target has Vulnerable
+            this.addToBot(new DamageAction(m, BindingHelper.makeInfo(this, p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
+        } else {
+            //Deal normal damage if they don't
+            this.addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.BLUNT_LIGHT));
+        }
+    }
+```
+
+If you want to manually bind damage mods but your card does not create a damage info to bind, you can instead bind the action it creates. This action will then pass any damage mods on for you.
+```Java
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        //You can define the action, bind it, and add it
+        MyComplicatedAction action = new MyComplicatedAction(p, p.hand.size(), getAverageMonsterHP(), p.currentHealth >= 42);
+        BindingHelper.bindAction(this, action)
+        this.addToBot(action);
+        //You can also directly bind the action while adding it, if you prefer
+        this.addToBot(BindingHelper.makeAction(this, new MyComplicatedAction(p, p.hand.size(), getAverageMonsterHP(), p.currentHealth >= 42)));
+    }
+```
+
+### Example Card
+Here an an example card using the previous example modifier. It deals 8 leech damage.
+```Java
+public class LifeTap extends AbstractDynamicCard {
+
+    public static final String ID = YourModID.makeID(LifeTap.class.getSimpleName());
+    public static final String IMG = makeCardPath("LifeTap.png");
+
+    private static final CardRarity RARITY = CardRarity.RARE;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
+    private static final CardType TYPE = CardType.ATTACK;
+    public static final CardColor COLOR = YourColorHere;
+
+    private static final int COST = 2;
+    private static final int DAMAGE = 8;
+    private static final int UPGRADE_PLUS_DMG = 2;
+
+    public LifeTap() {
+        super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
+        baseDamage = damage = DAMAGE;
+        this.exhaust = true;
+        this.tags.add(CardTags.HEALING);
+        DamageModifierManager.addModifier(this, new LeechDamage());
+    }
+
+    // Actions the card should do.
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        //This hit will automatically bind as it is in the cards use() method
+        this.addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
+    }
+
+    // Upgraded stats.
+    @Override
+    public void upgrade() {
+        if (!upgraded) {
+            upgradeName();
+            upgradeDamage(UPGRADE_PLUS_DMG);
+            initializeDescription();
+        }
+    }
+}
+```
+**Accompanying Json** - Using an icon is optional
+```Json
+  "YourModID:LifeTap": {
+    "NAME": "Life Tap",
+    "DESCRIPTION": "Deal !D! [YourModID:DrainIcon] damage."
+  },
+```
+
+## Adding Damage Modifiers via Powers / Relics
+
+There may be times where you do not want to bake a damage mod directly into a card, but would rather allow a power/relic to apply mods for you. For this, we have 2 hooks to use, DamageModApplyingPower and DamageModApplyingRelic. The power hooks will trigger for any DamageInfo created where the owner of the power is the damage source, whereas the Relic hooks are instead exclusive to the player. The hooks provided by DamageModApplying interfaces are as follows:
+
+```Java
+boolean shouldPushMods(DamageInfo infoMayBeNull, Object instigator, List<AbstractDamageModifier> activeDamageModifiers)
+
+List<AbstractDamageModifier> modsToPush(DamageInfo infoMayBeNull, Object instigator, List<AbstractDamageModifier> activeDamageModifiers)
+
+void onAddedDamageModsToDamageInfo(DamageInfo info, Object instigator)
+```
+`shouldPushMods` takes a DamageInfo (which may be null), an Object that instigated the creation of the damage info (if an instigator was bound, otherwise it may be null), and a list of damagemods that have already been bound to the DamageInfo. If it returns true, the list of mods in modsToPush will be added.
+
+`modsToPush` takes the same params as the previous, and returns a list of damage mods you want to add. Be sure to return a new list, and don't modify the one passed as a parameter. Of note, this will also emulate adding mods for the purpose of damage calculation within a cards applyPowers and calculateCardDamage hooks. For instance, pushing a mod that deals double damage to enemies with full hp will render the increased damage on the card even though no DamageInfo is created yet.
+
+`onAddedDamageModsToDamageInfo` is an optional hook that triggers upon this _actually_ applying damage mods to a DamageInfo. It is not called when pushing mods for the purpose of card damage calculation. This acts as an easy way to know the power actually triggered in a tangible way. An example use case would be if a power only applied a damage mod to the next 3 cards you play, this hook can be used to reduce the power. If you do this route, do be mindful that if a card creates 2 damageinfos, this hook will get called twice for that card.
+
+### Example Power
+This power applies FireDamage to Attack cards if they dont already have FireDamage, and will not trigger on DamageInfos created from other instigators such as Orbs
+```Java
+public class FireDamagePower extends AbstractPower implements DamageModApplyingPower {
+
+    ...
+
+    public FireDamagePower(AbstractCreature owner) {
+        this.name = NAME;
+        this.ID = POWER_ID;
+        this.owner = owner;
+        this.loadRegion("firebreathing");
+        updateDescription();
+    }
+
+    @Override
+    public void updateDescription() {
+        description = DESCRIPTIONS[0];
+    }
+
+    @Override
+    public boolean shouldPushMods(DamageInfo damageInfo, Object o, List<AbstractDamageModifier> list) {
+        return o instanceof AbstractCard && ((AbstractCard) o).type == AbstractCard.CardType.ATTACK && list.stream().noneMatch(mod -> mod instanceof FireDamage);
+    }
+
+    @Override
+    public List<AbstractDamageModifier> modsToPush(DamageInfo damageInfo, Object o, List<AbstractDamageModifier> list) {
+        return Collections.singletonList(new FireDamage());
+    }
+}
+```
+
+## Using Damage Modifiers on Anything Else
+
+To use a damage modifier on something other than a card, we no longer need DamageModiferManager, we instead use DamageModContainers and manual damage binding. In these example, we use a DamageModContainer to make a relic that deals 5 Fire damage to all enemies, and an Orb that deals Fire damage to the enemy with the most HP when evoked. We will again assume the required damage mods were already created.
+```Java
+public class FireFlower extends CustomRelic {
+
+    ...
+
+    private static final int DAMAGE = 5;
+    private final DamageModContainer container;
+
+    public FireFlower() {
+        super(ID, IMG, OUTLINE, RelicTier.UNCOMMON, LandingSound.FLAT);
+        container = new DamageModContainer(this, new FireDamage());
+    }
+
+    @Override
+    public void atTurnStart() {
+        flash();
+        this.addToBot(new RelicAboveCreatureAction(AbstractDungeon.player, this));
+        this.addToBot(BindingHelper.makeAction(container, new DamageAllEnemiesAction(AbstractDungeon.player, DAMAGE, DamageInfo.DamageType.THORNS, AbstractGameAction.AttackEffect.FIRE)));
+    }
+   
+    ...
+}
+```
+
+```Java
+public class FireOrb extends AbstractOrb {
+
+    ...
+    private final DamageModContainer container;
+
+    public FireOrb () {
+        super(...);
+        ...
+        container = new DamageModContainer(this, new FireDamage());
+    }
+
+    @Override
+    public void onEvoke() {
+        AbstractMonster t = null;
+        for (AbstractMonster mon : AbstractDungeon.getMonsters().monsters) {
+            if (!mon.isDeadOrEscaped()) {
+                if (t == null || mon.currentHealth > t.currentHealth) {
+                    t = mon;
+                }
+            }
+        }
+        if (t != null) {
+            int damage = evokeAmount;
+            if (t.hasPower(LockOnPower.POWER_ID)) {
+                damage *= LockOnPower.MULTIPLIER;
+            }
+            this.addToBot(new DamageAction(t, BindingHelper.makeInfo(container, p, damage, DamageInfo.DamageType.THORNS), AbstractGameAction.AttackEffect.FIRE));
+        }
+    }
+
+    ...
+
+}
+```
+
+## Manual Card Binding Examples
+
+### Example Modifier 2
+This modifier ignores Block and applies Poison instead of dealing damage to the target. If the object is a card then it also adds a Poison keyword and descriptor to the card using Icons. This modifier also allows you disabling automatic binding, which we will see a use case for in the card example below.
+```Java
+public class PoisonDamage extends AbstractDamageModifier {
+    public static final String ID = YourModID.makeID("PoisonDamage");
+    public final CardStrings cardStrings = CardCrawlGame.languagePack.getCardStrings(ID);
+
+    TooltipInfo poisonTooltip = null;
+
+    public PoisonDamage() {
+        this(true);
+    }
+
+    public PoisonDamage(boolean autoBind) {
+        this.automaticBindingForCards = autoBind;
+    }
+
+    //A simple override allows this damage to directly ignore any Block the target has
+    @Override
+    public boolean ignoresBlock(AbstractCreature target) {
+        return true;
+    }
+
+    //Using onAttackToChangeDamage here will grab the damage that would have been dealt and allows us to modify it, returning 0.
+    //Since we have the damage amount at this point, we can also simply apply Poison to the target equal this amount.
+    @Override
+    public int onAttackToChangeDamage(DamageInfo info, int damageAmount, AbstractCreature target) {
+        this.addToTop(new ApplyPowerAction(target, info.owner, new PoisonPower(target, info.owner, damageAmount)));
+        return 0;
+    }
+
+    @Override
+    public TooltipInfo getCustomTooltip() {
+        if (poisonTooltip == null) {
+            poisonTooltip = new TooltipInfo(cardStrings.DESCRIPTION, cardStrings.EXTENDED_DESCRIPTION[0]);
+        }
+        return poisonTooltip;
+    }
+
+    @Override
+    public String getCardDescriptor() {
+        return cardStrings.NAME;
+    }
+
+    public boolean isInherent() {
+        return true;
+    }
+}
+```
+**Accompanying Json** - Using an icon is optional
+```Json
+  "YourModID:PoisonDamage": {
+    "NAME": "Poison",
+    "DESCRIPTION": "Poison Damage [YourModID:PoisonIcon]",
+    "EXTENDED_DESCRIPTION": ["Ignores #yBlock and applies #yPoison instead of dealing damage."]
+  }
+```
+
+### Example Card 2
+Here an an example card using the above modifier. It deals 4 damage, then deals 4 poison damage.
+```Java
+public class PoisonShock extends AbstractDynamicCard {
+
+    public static final String ID = YourModID.makeID(PoisonShock.class.getSimpleName());
+    public static final String IMG = makeCardPath("PoisonShock.png");
+
+    private static final CardRarity RARITY = CardRarity.COMMON;
+    private static final CardTarget TARGET = CardTarget.ENEMY;
+    private static final CardType TYPE = CardType.ATTACK;
+    public static final CardColor COLOR = YourColorHere;
+
+    private static final int COST = 1;
+    private static final int DAMAGE = 4;
+    private static final int UPGRADE_PLUS_DMG = 2;
+
+    public PoisonShock() {
+        super(ID, IMG, COST, TYPE, COLOR, RARITY, TARGET);
+        baseDamage = damage = DAMAGE;
+        DamageModifierManager.addModifier(this, new PoisonDamage(false)); //We disable auto binding here so the mod doesnt apply to both hits
+    }
+
+    // Actions the card should do.
+    @Override
+    public void use(AbstractPlayer p, AbstractMonster m) {
+        //This hit is unbound so it deals normal damage
+        this.addToBot(new DamageAction(m, new DamageInfo(p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_HORIZONTAL));
+        //This hit is bound and will do our poison damage
+        this.addToBot(new DamageAction(m, BindingHelper.makeInfo(this, p, damage, damageTypeForTurn), AbstractGameAction.AttackEffect.SLASH_VERTICAL));
+    }
+
+    // Upgraded stats.
+    @Override
+    public void upgrade() {
+        if (!upgraded) {
+            upgradeName();
+            upgradeDamage(UPGRADE_PLUS_DMG);
+            initializeDescription();
+        }
+    }
+}
+```
+**Accompanying Json** - Using an icon is optional
+```Json
+  "YourModID:PoisonShock": {
+    "NAME": "Poison Shock",
+    "DESCRIPTION": "Deal !D! damage. NL Deal !D! [YourModID:PoisonIcon] damage."
+  },
+```

--- a/research/stslib_ExhaustiveField.java
+++ b/research/stslib_ExhaustiveField.java
@@ -1,0 +1,19 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+public class ExhaustiveField
+{
+    @SpirePatch(
+            clz=AbstractCard.class,
+            method=SpirePatch.CLASS
+    )
+    public static class ExhaustiveFields
+    {
+        public static SpireField<Integer> exhaustive = new SpireField<>(() -> -1);
+        public static SpireField<Integer> baseExhaustive = new SpireField<>(() -> -1);
+        public static SpireField<Boolean> isExhaustiveUpgraded = new SpireField<>(() -> false);
+    }
+}

--- a/research/stslib_ExhaustiveVariable.java
+++ b/research/stslib_ExhaustiveVariable.java
@@ -1,0 +1,66 @@
+package com.evacipated.cardcrawl.mod.stslib.variables;
+
+import basemod.abstracts.DynamicVariable;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.ExhaustiveField;
+import com.evacipated.cardcrawl.mod.stslib.powers.ExhaustiveNegationPower;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
+public class ExhaustiveVariable extends DynamicVariable
+{
+    @Override
+    public String key()
+    {
+        return "stslib:ex";
+    }
+
+    @Override
+    public boolean isModified(AbstractCard card)
+    {
+        return ExhaustiveField.ExhaustiveFields.exhaustive.get(card).intValue() != ExhaustiveField.ExhaustiveFields.baseExhaustive.get(card).intValue();
+    }
+
+    @Override
+    public int value(AbstractCard card)
+    {
+        return ExhaustiveField.ExhaustiveFields.exhaustive.get(card);
+    }
+
+    @Override
+    public int baseValue(AbstractCard card)
+    {
+        return ExhaustiveField.ExhaustiveFields.baseExhaustive.get(card);
+    }
+
+    @Override
+    public boolean upgraded(AbstractCard card)
+    {
+        return ExhaustiveField.ExhaustiveFields.isExhaustiveUpgraded.get(card);
+    }
+
+    public static void setBaseValue(AbstractCard card, int amount)
+    {
+        ExhaustiveField.ExhaustiveFields.baseExhaustive.set(card, amount);
+        ExhaustiveField.ExhaustiveFields.exhaustive.set(card, amount);
+        card.initializeDescription();
+    }
+
+    public static void upgrade(AbstractCard card, int amount)
+    {
+        ExhaustiveField.ExhaustiveFields.isExhaustiveUpgraded.set(card, true);
+        setBaseValue(card, ExhaustiveField.ExhaustiveFields.baseExhaustive.get(card) + amount);
+    }
+
+    public static void increment(AbstractCard card)
+    {
+        if (AbstractDungeon.player.hasPower(ExhaustiveNegationPower.POWER_ID)) {
+            AbstractDungeon.player.getPower(ExhaustiveNegationPower.POWER_ID).onSpecificTrigger();
+            return;
+        }
+        ExhaustiveField.ExhaustiveFields.exhaustive.set(card, ExhaustiveField.ExhaustiveFields.exhaustive.get(card) - 1);
+        if (ExhaustiveField.ExhaustiveFields.exhaustive.get(card) <= 0) {
+            card.exhaust = true;
+        }
+        card.initializeDescription();
+    }
+}

--- a/research/stslib_Flavor-Text.md
+++ b/research/stslib_Flavor-Text.md
@@ -1,0 +1,28 @@
+Flavor text is a great way to add a little extra color to your cards.  They are a tooltip without a header.  You can add the flavor text to cards within the CardStrings.json.  Add a FLAVOR field like so:
+```
+  "${ModID}:PhantomFist": {
+    "NAME": "Phantom Fist",
+    "DESCRIPTION": "Deal !D! damage.",
+    "FLAVOR": "It's like hitting them with a fist, except the fist is the size of a watermelon and made of steel."
+  },
+```
+Cards without a FLAVOR field will simply not use the flavor text feature.
+
+If for some reason you need to modify or read the flavor text in your code, there are two SpireFields you can use to do so.  
+ `CardStringsFlavorField.FLAVOR` for the field in a CardStrings object, and `AbstractCardFlavorFields.flavor` for the field in an AbstractCard object.
+
+It is recommended that you change the box color and text color from their default values.  Cards can have the color of the flavor text box set with the SpireField `AbstractCardFlavorFields.boxColor`.  They can also have the color of their text set with the SpireField `AbstractCardFlavorFields.textColor`.
+
+The box type can also be set with `AbstractCardFlavorFields.boxType`.  WHITE is a white box with grey edges.  Setting the color is straightforward and the edges of the box are darker than the central part.  TRADITIONAL looks like a normal tip before applying color, so when you apply a light color it will still be darker.  The edges are also lighter than the central part.  CUSTOM is where you supply your own images for the box.  `AbstractCardFlavorFields.boxTop` needs to be set to a Texture object, this is an image for the top part of the box.  Ditto for boxMid and boxBot.  The middle texture will get stretched depending on the height of the box, so keep that in mind when designing a texture.
+
+Flavor text for potions is now available!  Use `PotionFlavorFields` instead of `AbstractCardFlavorFields`.  The options are the same.
+
+<br/><br/>
+
+![Fist](https://user-images.githubusercontent.com/56576391/167802823-e6f76221-256e-4dc4-90ea-e7b5223f357a.png)
+<p align="center"> Flavor text on a card. <\p>
+
+<br/><br/>
+
+![PotionFlavor](https://user-images.githubusercontent.com/56576391/167801617-d4e69ef1-2a8a-4f20-8560-b0bb7a19887a.png)
+<p align="center"> Flavor text on a potion. </p>

--- a/research/stslib_FleetingField.java
+++ b/research/stslib_FleetingField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class FleetingField
+{
+    public static SpireField<Boolean> fleeting = new SpireField<>(() -> false);
+}

--- a/research/stslib_GraveField.java
+++ b/research/stslib_GraveField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class GraveField
+{
+    public static SpireField<Boolean> grave = new SpireField<>(() -> false);
+}

--- a/research/stslib_Icons.md
+++ b/research/stslib_Icons.md
@@ -1,0 +1,75 @@
+## Making custom icons
+There may be times where you may want to add an icon to a keyword tooltip for flavor, or even replace a keyword on a card with an icon entirely, such as using an icon to denote different damage types. For this, we have support for adding custom icons like using the small energy orb [E].
+
+To make an icon, first make an icon class by extending AbstractCustomIcon. Your icon requires an ID (which should be prefixed with your mod ID just like making cards and powers), as well as a Texture or TextureAtlas so it knows what to render. By default, icons will render the same size as the small energy orb, though this can be overridden.
+
+The following is an example Icon using the string "Electric" with makeID. The code for using this this Icon will be `[ShadowSiren:ElectricIcon]`, as the `[` and `Icon]` parts are automatically added.
+```Java
+public class ElectricIcon extends AbstractCustomIcon {
+    public static final String ID = ShadowSirenMod.makeID("Electric");
+    private static ElectricIcon singleton;
+
+    public ElectricIcon() {
+        super(ID, TextureLoader.getTexture("ShadowSirenResources/images/icons/Electric.png"));
+    }
+
+    public static ElectricIcon get()
+    {
+        if (singleton == null) {
+            singleton = new ElectricIcon();
+        }
+        return singleton;
+    }
+}
+```
+This Icon has been created, but we still need to register it to be able to use it. Icons should be registered _before_ any cards that use them, similar to dynamic variables. Making a `get()` method is not mandatory as we could use `new ElectricIcon()` in this example, though it is preferable.
+```Java
+    @Override
+    public void receiveEditCards() {
+        //Add icons
+        CustomIconHelper.addCustomIcon(ElectricIcon.get());
+        ...
+
+        // Add the Dynamic variables
+        ...
+        
+        // Add the cards
+        ...
+    }
+```
+
+## Using Icons in Descriptions
+Icons can be added to the descriptions of cards, as well as in tooltips such as power tips, keyword tips, and relic descriptions (basically anywhere you would reasonably use [E]). To use an Icon in your text, simply add the icon code to the text string.
+
+**Cards** - Icons will work in the same was as [E] in the descriptions.
+```Json
+  "ShadowSiren:ElectroStrike": {
+    "NAME": "Electro Strike",
+    "DESCRIPTION": "Deal !D! [ShadowSiren:ElectricIcon] damage."
+  }
+```
+**Keywords** - Using PROPER_NAME allows you to use a keyword in a card and have the keyword tooltip use an icon. Icons also work in the descriptions.
+```Json
+  {
+    "PROPER_NAME": "Keyword [YourModID:GearIcon]",
+    "NAMES": [
+      "keyword"
+    ],
+    "DESCRIPTION": "[YourModID:HeartIcon] Icons work here too."
+  },
+  {
+    "PROPER_NAME": "Multiword Keyword [YourModID:IncreaseIcon]",
+    "NAMES": [
+      "Multiword Keyword",
+      "multiword_keyword"
+    ],
+    "DESCRIPTION": "Icons work at the end of a sentence with a space before the period [YourModID:RunningIcon] ."
+  },
+```
+**Powers** - Icons will work in the descriptions for powers. You can also put an icon in the power name and it will appear before the image for the power. It will look silly in most cases however.
+```Json
+  "YourModID:FancyPower": {
+    "NAME": "Power Name [YourModID:BadIdeaIcon]",
+    "DESCRIPTIONS": ["Icons [YourModID:BetterIdeaIcon] also work in here."]
+  },
+```

--- a/research/stslib_Keywords.md
+++ b/research/stslib_Keywords.md
@@ -1,0 +1,21 @@
+Keyword | Description | Field
+--- | --- | ---
+Autoplay | This card automatically plays itself when drawn. |  `AutoplayField.autoplay`
+Exhaustive | Exhausts after a certain number of uses. | `ExhaustiveVariable.setBaseValue`
+Fleeting | This card Purges and is removed from your deck on use. | `FleetingField.fleeting`
+Grave | Start each combat with this card in your discard pile. | `GraveField.grave`
+Persist | Only discards after a certain number of uses each turn. | `PersistFields.setBaseValue`
+Purge | Removed until end of combat. Does NOT go to your exhaust pile. | `PurgeField.purge`
+Refund | Returns energy spent on playing the card, up to the Refund value. | `RefundVariable.setBaseValue`
+Retain | Not discarded at the end of your turn. | `AlwaysRetainField.alwaysRetain`
+Snecko | When drawn, this card randomizes its cost. | `SneckoField.snecko`
+Soulbound | Cannot be removed from your deck. | `SoulboundField.soulbound`
+Startup | Triggers at the start of each combat. | `StartupCard` interface
+
+### Usage
+
+For interfaces, implement them in your card class. For fields, set their values in the constructor of the card. The specifics may vary slightly.
+
+For example, to give a card Exhaustive 2 you would do `ExhaustiveVariable.setBaseValue(this, 2);`. For those that are true or false, it will be more along the lines of `PurgeField.purge.set(this, true);`
+
+All keywords should use the `stslib:` prefix in card text. Effects with numeric values also come with their own dynamic variables to use in card text. For Exhaustive, it would be `stslib:Exhaustive !stslib:ex!.`

--- a/research/stslib_PersistFields.java
+++ b/research/stslib_PersistFields.java
@@ -1,0 +1,34 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        clz=AbstractCard.class,
+        method=SpirePatch.CLASS
+)
+public class PersistFields
+{
+    public static SpireField<Integer> persist = new SpireField<>(() -> -1);
+    public static SpireField<Integer> basePersist = new SpireField<>(() -> -1);
+    public static SpireField<Boolean> isPersistUpgraded = new SpireField<>(() -> false);
+
+    public static void setBaseValue(AbstractCard card, int amount)
+    {
+        basePersist.set(card, amount);
+        persist.set(card, amount);
+        card.initializeDescription();
+    }
+
+    public static void upgrade(AbstractCard card, int amount)
+    {
+        isPersistUpgraded.set(card, true);
+        setBaseValue(card, basePersist.get(card) + amount);
+    }
+
+    public static void decrement(AbstractCard card)
+    {
+        persist.set(card, persist.get(card) - 1);
+    }
+}

--- a/research/stslib_PersistVariable.java
+++ b/research/stslib_PersistVariable.java
@@ -1,0 +1,38 @@
+package com.evacipated.cardcrawl.mod.stslib.variables;
+
+import basemod.abstracts.DynamicVariable;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.PersistFields;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+public class PersistVariable extends DynamicVariable
+{
+    @Override
+    public String key()
+    {
+        return "stslib:persist";
+    }
+
+    @Override
+    public boolean isModified(AbstractCard card)
+    {
+        return PersistFields.persist.get(card).intValue() != PersistFields.basePersist.get(card).intValue();
+    }
+
+    @Override
+    public int value(AbstractCard card)
+    {
+        return PersistFields.persist.get(card);
+    }
+
+    @Override
+    public int baseValue(AbstractCard card)
+    {
+        return PersistFields.basePersist.get(card);
+    }
+
+    @Override
+    public boolean upgraded(AbstractCard card)
+    {
+        return PersistFields.isPersistUpgraded.get(card);
+    }
+}

--- a/research/stslib_Power-Hooks.md
+++ b/research/stslib_Power-Hooks.md
@@ -1,0 +1,31 @@
+Interface Name | Description
+--- | ---
+BeforeRenderIntentPower | Hook for the check if Intent should be rendered.
+BetterOnApplyPowerPower | An improvement to the onApplyPower hook. Allows you to negate the power being applied and change the stack amount.
+BetterOnExhaustPower | An improvement to the onExhaust hook. Includes what CardGroup the card comes from and works for powers on monsters.
+OnLoseBlockPower | Hook for when the owner loses Block.
+OnLoseTempHpPower | Hook for when the owner loses Temporary HP.
+OnMyBlockBrokenPower | Hook for when the owner's block is completely broken.
+OnPlayerDeathPower | Hook for when the player dies. Can stop the player from dying.
+OnReceivePowerPower | Hook for when a buff/debuff is applied to the owner. Can negate the buff/debuff.
+HealthBarRenderPower | Not a hook, allows powers to render on the hp bar like Poison.
+InvisiblePower | Not a hook, makes a power not appear in a creature's list of powers.
+NonStackablePower | Not a hook, allows the same power to non stack and choose when to stack or not stack.
+TwoAmountPower | Not a hook, allows a power to have two numbers on it.
+DamageModApplyingPower | Hook for when a DamageInfo is created with the owner as the source with the purpose of applying Damage Mods.
+OnCreateBlockInstancePower | Hook for when the owner gains Block with the purpose of applying Block Mods.
+OnDrawPileShufflePower | Hook for when the draw pile gets shuffled.
+OnCreateCardInterface | Hook for when a card is created during combat.
+
+For any of these, add them as an interface your power implements.
+```Java
+public class MyPower extends AbstractPower implements OnReceivePowerPower
+{
+    ...
+    @Override
+    public boolean onReceivePower(AbstractPower power, AbstractCreature target, AbstractCreature source)
+    {
+        ...
+    }
+}
+```

--- a/research/stslib_RefundFields.java
+++ b/research/stslib_RefundFields.java
@@ -1,0 +1,16 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        clz=AbstractCard.class,
+        method=SpirePatch.CLASS
+)
+public class RefundFields
+{
+    public static SpireField<Integer> refund = new SpireField<>(() -> 0);
+    public static SpireField<Integer> baseRefund = new SpireField<>(() -> 0);
+    public static SpireField<Boolean> isRefundUpgraded = new SpireField<>(() -> false);
+}

--- a/research/stslib_RefundVariable.java
+++ b/research/stslib_RefundVariable.java
@@ -1,0 +1,51 @@
+package com.evacipated.cardcrawl.mod.stslib.variables;
+
+import basemod.abstracts.DynamicVariable;
+import com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard.RefundFields;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+public class RefundVariable extends DynamicVariable
+{
+    @Override
+    public String key()
+    {
+        return "stslib:refund";
+    }
+
+    @Override
+    public boolean isModified(AbstractCard card)
+    {
+        return RefundFields.refund.get(card).intValue() != RefundFields.baseRefund.get(card).intValue();
+    }
+
+    @Override
+    public int value(AbstractCard card)
+    {
+        return RefundFields.refund.get(card);
+    }
+
+    @Override
+    public int baseValue(AbstractCard card)
+    {
+        return RefundFields.baseRefund.get(card);
+    }
+
+    @Override
+    public boolean upgraded(AbstractCard card)
+    {
+        return RefundFields.isRefundUpgraded.get(card);
+    }
+
+    public static void setBaseValue(AbstractCard card, int amount)
+    {
+        RefundFields.baseRefund.set(card, amount);
+        RefundFields.refund.set(card, amount);
+        card.initializeDescription();
+    }
+
+    public static void upgrade(AbstractCard card, int amount)
+    {
+        RefundFields.isRefundUpgraded.set(card, true);
+        setBaseValue(card, RefundFields.baseRefund.get(card) + amount);
+    }
+}

--- a/research/stslib_Relic-Hooks.md
+++ b/research/stslib_Relic-Hooks.md
@@ -1,0 +1,35 @@
+Interface Name | Description
+--- | ---
+ClickableRelic | Gives a relic right-click to activate functionality.
+OnChannelRelic | Hook for when an Orb is Channeled.
+BeforeRenderIntentRelic | Hook for the check if Intent should be rendered.
+BetterOnLoseHpRelic | An improvement to the onLoseHp hook. Includes the DamageInfo and allows you to change the damage amount.
+BetterOnSmithRelic | An improvement to the onSmith hook. Actually triggers on the smith happening and passes the smithed card.
+BetterOnUsePotionRelic | An improvement to the onUsePotion hook. Includes what potion was used.
+SuperRareRelic | Think Rare isn't rare enough? Make your relic super rare!
+OnReceivePowerRelic | Hook for when a buff/debuff is applied to the player. Can negate the buff/debuff.
+OnApplyPowerRelic | Hook for when the player applies a buff/debuff to something. Can negate the buff/debuff.
+OnAnyPowerAppliedRelic | Hook for when a buff/debuff is applied to any creature by any creature. Can negate the buff/debuff.
+OnAfterUseCardRelic | Mirrors the AbstractPower hook `onAfterUseCard` to relics
+OnSkipCardRelic | Hook for when a card reward is skipped.
+OnRemoveCardFromMasterDeckRelic | Hook for when a card is removed from the master deck.
+OnLoseTempHpRelic | Hook for when owner loses Temporary Hp.
+OnLoseBlockRelic | Hook for when owner loses Block.
+OnPlayerDeathRelic | Hook for when the player dies. Can stop the player from dying.
+DamageModApplyingRelic | Hook for when a DamageInfo is created with the player as a source with the purpose of applying Damage Mods.
+OnCreateBlockInstanceRelic | Hook for when the player gains Block with the purpose of applying Block Mods.
+CardRewardSkipButtonRelic | Interface for a relic that adds a button to skip card rewards that trigger an effect, like Singing Bowl.
+OnCreateCardInterface | Hook for when a card is created during combat.
+ 
+For any of these, add them as an interface your relic implements.
+```Java
+public class MyRelic extends AbstractRelic implements OnChannelRelic
+{
+    ...
+    @Override
+    public void onChannel(AbstractOrb orb)
+    {
+        ...
+    }
+}
+```

--- a/research/stslib_SneckoField.java
+++ b/research/stslib_SneckoField.java
@@ -1,0 +1,32 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class SneckoField
+{
+    public static SpireField<Boolean> snecko = new SneckoFieldType(() -> false);
+
+    // This is done so card cost is automatically set to -1
+    private static class SneckoFieldType extends SpireField<Boolean>
+    {
+        SneckoFieldType(DefaultValue<Boolean> defaultValue)
+        {
+            super(defaultValue);
+        }
+
+        @Override
+        public void set(Object __intance, Boolean value)
+        {
+            super.set(__intance, value);
+            if (value && __intance instanceof AbstractCard) {
+                ((AbstractCard)__intance).cost = -1;
+            }
+        }
+    }
+}

--- a/research/stslib_SoulboundField.java
+++ b/research/stslib_SoulboundField.java
@@ -1,0 +1,13 @@
+package com.evacipated.cardcrawl.mod.stslib.fields.cards.AbstractCard;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpireField;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+
+@SpirePatch(
+        cls="com.megacrit.cardcrawl.cards.AbstractCard",
+        method=SpirePatch.CLASS
+)
+public class SoulboundField
+{
+    public static SpireField<Boolean> soulbound = new SpireField<>(() -> false);
+}

--- a/research/stslib_custom_icon_helper.java
+++ b/research/stslib_custom_icon_helper.java
@@ -1,0 +1,35 @@
+package com.evacipated.cardcrawl.mod.stslib.icons;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.TreeMap;
+
+public class CustomIconHelper {
+    private static final HashMap<String, AbstractCustomIcon> icons = new HashMap<>();
+
+    public static void addCustomIcon(AbstractCustomIcon icon) {
+        icons.put(icon.cardCode().toLowerCase(), icon);
+    }
+
+    public static AbstractCustomIcon getIcon(String key) {
+        return icons.get(key.toLowerCase());
+    }
+
+    public static Collection<AbstractCustomIcon> getAllIcons() {
+        return icons.values();
+    }
+
+    public static ArrayList<AbstractCustomIcon> iconsOnCard(AbstractCard card) {
+        TreeMap<Integer, AbstractCustomIcon> icons = new TreeMap<>();
+        for (AbstractCustomIcon i : getAllIcons()) {
+            int indexOf = card.rawDescription.indexOf(i.cardCode());
+            if (indexOf > -1) {
+                icons.put(indexOf, i);
+            }
+        }
+        return new ArrayList<>(icons.values());
+    }
+}

--- a/research/stslib_home.md
+++ b/research/stslib_home.md
@@ -1,0 +1,13 @@
+## Features
+
+* [Actions](https://github.com/kiooeht/StSLib/wiki/Actions)
+* [Cards](https://github.com/kiooeht/StSLib/wiki/Cards)
+* [Keywords](https://github.com/kiooeht/StSLib/wiki/Keywords)
+* [Relic Hooks](https://github.com/kiooeht/StSLib/wiki/Relic-Hooks)
+* [Power Hooks](https://github.com/kiooeht/StSLib/wiki/Power-Hooks)
+* [Custom Targeting](https://github.com/kiooeht/StSLib/wiki/Custom-Targeting)
+* [Icons](https://github.com/kiooeht/StSLib/wiki/Icons)
+* [Damage Modifiers](https://github.com/kiooeht/StSLib/wiki/Damage-Modifiers)
+* [Block Modifiers](https://github.com/kiooeht/StSLib/wiki/Block-Modifiers)
+* [Flavor Text](https://github.com/kiooeht/StSLib/wiki/Flavor-Text)
+* [Colored Damage Numbers](https://github.com/kiooeht/StSLib/wiki/Colored-Damage-Numbers)

--- a/research/stslib_keyword_source.java
+++ b/research/stslib_keyword_source.java
@@ -1,0 +1,12 @@
+package com.evacipated.cardcrawl.mod.stslib;
+
+import basemod.helpers.KeywordColorInfo;
+
+public class Keyword
+{
+    public String ID = "";
+    public String PROPER_NAME;
+    public String[] NAMES;
+    public String DESCRIPTION;
+    public KeywordColorInfo COLOR;
+}

--- a/research/stslib_keyword_tooltips.java
+++ b/research/stslib_keyword_tooltips.java
@@ -1,0 +1,3 @@
+// Retrieval note:
+// Attempted to download KeywordTooltips.java from https://raw.githubusercontent.com/kiooeht/StSLib/master/src/main/java/com/evacipated/cardcrawl/mod/stslib/KeywordTooltips.java
+// GitHub responded with HTTP 404 on this date, so no source snapshot was captured.

--- a/research/stslib_overview.md
+++ b/research/stslib_overview.md
@@ -1,0 +1,4 @@
+# Retrieval note
+
+Attempted to download StSLib overview documentation from https://raw.githubusercontent.com/kiooeht/ModTheSpire/master/docs/StS-Lib.md.
+GitHub responded with HTTP 404 on this date, so no content was available at that path.

--- a/research/stslib_readme.md
+++ b/research/stslib_readme.md
@@ -1,0 +1,12 @@
+# StSLib #
+StSLib provides a number of keywords and mechanics for other mods to use.
+
+StSLib aims to implement common mod features so each mod doesn't have to reimplement them.
+
+### Requires:
+ * [BaseMod](https://github.com/daviscook477/BaseMod/releases)
+ * [ModTheSpire](https://github.com/kiooeht/ModTheSpire)
+ 
+# Features
+
+See the [wiki](https://github.com/kiooeht/StSLib/wiki).

--- a/research/stslib_wiki.md
+++ b/research/stslib_wiki.md
@@ -1,0 +1,2382 @@
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html
+  lang="en"
+  
+  data-color-mode="auto" data-light-theme="light" data-dark-theme="dark"
+  data-a11y-animated-images="system" data-a11y-link-underlines="true"
+  
+  >
+
+
+
+
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://github.githubassets.com">
+  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+  <link rel="preconnect" href="https://github.githubassets.com" crossorigin>
+  <link rel="preconnect" href="https://avatars.githubusercontent.com">
+
+  
+
+  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/light-6448649c7147.css" /><link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/light_high_contrast-42fc7e3b06b7.css" /><link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/dark-d17b946fc2c5.css" /><link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/dark_high_contrast-1b924088c83a.css" /><link data-color-theme="light" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light-6448649c7147.css" /><link data-color-theme="light_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_high_contrast-42fc7e3b06b7.css" /><link data-color-theme="light_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_colorblind-44cfaf0c8f7b.css" /><link data-color-theme="light_colorblind_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_colorblind_high_contrast-979217efd93e.css" /><link data-color-theme="light_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_tritanopia-4d5383026bfa.css" /><link data-color-theme="light_tritanopia_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/light_tritanopia_high_contrast-ff6ff8532348.css" /><link data-color-theme="dark" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark-d17b946fc2c5.css" /><link data-color-theme="dark_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_high_contrast-1b924088c83a.css" /><link data-color-theme="dark_colorblind" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_colorblind-654786382462.css" /><link data-color-theme="dark_colorblind_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_colorblind_high_contrast-ecca008c6f6e.css" /><link data-color-theme="dark_tritanopia" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_tritanopia-fff376053989.css" /><link data-color-theme="dark_tritanopia_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_tritanopia_high_contrast-49adf52571e5.css" /><link data-color-theme="dark_dimmed" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_dimmed-66d97c13c98a.css" /><link data-color-theme="dark_dimmed_high_contrast" crossorigin="anonymous" media="all" rel="stylesheet" data-href="https://github.githubassets.com/assets/dark_dimmed_high_contrast-c58f1d0432b9.css" />
+
+  <style type="text/css">
+    :root {
+      --tab-size-preference: 4;
+    }
+
+    pre, code {
+      tab-size: var(--tab-size-preference);
+    }
+  </style>
+
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-primitives-dc7ca6859caf.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-f96b923db733.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/global-241f81e44892.css" />
+    <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/github-086c1af66525.css" />
+  <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/repository-5d735668c600.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/wiki-0f9a446f06a3.css" />
+
+  
+
+  <script type="application/json" id="client-env">{"locale":"en","featureFlags":["alternate_user_config_repo","api_insights_show_missing_data_banner","attestations_filtering","attestations_sorting","billing_fixed_amount_metered_configured_discounts","billing_use_current_discounts_list_dialog_v2","client_version_header","codespaces_prebuild_region_target_update","contact_requests_implicit_opt_in","contact_sales_locale_utm_medium","contentful_lp_enterprise","contentful_lp_footnotes","copilot_agent_cli_public_preview","copilot_agent_tasks_btn_code_nav","copilot_agent_tasks_btn_code_view","copilot_agent_tasks_btn_code_view_lines","copilot_agent_tasks_btn_file_reference","copilot_api_agentic_issue_marshal_yaml","copilot_api_draft_issue_code_search","copilot_chat_attach_multiple_images","copilot_chat_file_redirect","copilot_chat_multi_file_picker_attachment","copilot_chat_reduce_quota_checks","copilot_chat_search_bar_redirect","copilot_chat_selection_attachments","copilot_chat_vision_in_claude","copilot_chat_vision_skip_thread_create","copilot_coding_agent_diff_stats","copilot_coding_agent_ga","copilot_custom_copilots","copilot_custom_copilots_feature_preview","copilot_duplicate_thread","copilot_extensions_deprecation_notice","copilot_features_raycast_logo","copilot_file_block_ref_matching","copilot_free_to_paid_telem","copilot_ftp_hyperspace_upgrade_prompt","copilot_ftp_settings_upgrade","copilot_ftp_upgrade_to_pro_from_models","copilot_ftp_your_copilot_settings","copilot_global_overlay_v2","copilot_immersive_agent_branch_selection","copilot_immersive_structured_model_picker","copilot_loops_share_button","copilot_no_floating_button","copilot_read_shared_conversation","copilot_show_copilot_sub_issues_button_on_issues_page","copilot_spaces_duplicate","copilot_spaces_ga","copilot_spark_allow_empty_commit","copilot_spark_loading_webgl","copilot_spark_progressive_error_handling","copilot_spark_read_iteration_history_from_git_v2","copilot_spark_single_user_iteration","copilot_spark_use_billing_headers","copilot_spark_write_iteration_history_to_git","copilot_stable_conversation_view","copilot_workbench_agent_seed_tool","copilot_workbench_cache","copilot_workbench_connection_reload_banner","copilot_workbench_preview_analytics","copilot_workbench_ratelimit_fallback","copilot_workbench_refresh_on_wsod","copilot_workbench_synthetic_generation","dashboard_public_preview","direct_to_salesforce","dotcom_chat_client_side_skills","failbot_report_error_react_apps_on_page","ghost_pilot_confidence_truncation_25","ghost_pilot_confidence_truncation_40","global_search_multi_orgs","hpc_improve_dom_insertion_observer","hyperspace_diff_view","inp_reduced_threshold","insert_before_patch","issue_fields_report_usage","issues_copilot_cross_repo_assign","issues_copilot_repo_search_in_org","issues_react_blur_item_picker_on_close","issues_react_bots_timeline_pagination","issues_react_prohibit_title_fallback","issues_react_remove_placeholders","issues_sticky_sidebar","lifecycle_label_name_updates","link_contact_sales_swp_marketo","marketing_pages_search_explore_provider","mcp_registry_install","memex_mwl_filter_field_delimiter","migrate_toasts_to_banners_web_notifications","new_traffic_page_banner","override_pulse_legacy_url","primer_react_segmented_control_tooltip","primer_react_unified_portal_root","record_sso_banner_metrics","releases_update_ref_selector","remove_child_patch","repos_insights_remove_new_url","sample_network_conn_type","scheduled_reminders_updated_limits","show_edit_on_default_option","site_homepage_collaborate_video","site_homepage_contentful","site_msbuild_webgl_hero","spark_commit_on_default_branch","spark_show_data_access_on_publish","spark_sync_repository_after_iteration","viewscreen_sandbox","webp_support","workbench_default_sonnet4","workbench_store_readonly"],"copilotApiOverrideUrl":"https://api.githubcopilot.com"}</script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/high-contrast-cookie-f3788027bd8d.js"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/wp-runtime-e66a8aef74fb.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_oddbird_popover-polyfill_dist_popover-fn_js-468bf7cab607.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_stacktrace-parser_dist_stack-trace-parser_esm_js-node_modules_github_bro-2f4e04-280c10ec004d.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_arianotify-polyfill_ariaNotify-polyfill_js-node_modules_github_mi-c8eeba-690858154b11.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/environment-e36acb721009.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_primer_behaviors_dist_esm_index_mjs-7e8c9c5d642d.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_relative-time-element_dist_index_js-c98257dc79a7.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_selector-observer_dist_index_esm_js-7e4d99c9171d.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_auto-complete-element_dist_index_js-node_modules_github_catalyst_-0d7d60-b5d92aad9108.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_text-expander-element_dist_index_js-754f5b5e9e7e.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_filter-input-element_dist_index_js-node_modules_github_remote-inp-b5f1d7-fd008e5636c7.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_markdown-toolbar-element_dist_index_js-d41270eb61be.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_file-attachment-element_dist_index_js-node_modules_primer_view-co-c63e9a-b1f4633cac7f.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/github-elements-e1b8d79d7efc.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/element-registry-0cb008175814.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_github_hydro-analytics-c-2a6094-2f3b5bfd7e3b.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_braintree_browser-detection_dist_browser-detection_js-node_modules_githu-bb80ec-4e90f1d1076c.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_lit-html_lit-html_js-06c8637a6071.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_morphdom_dist_morphdom-esm_js-node_modules_swc_helpers_esm__define_property_js-5c587dccb470.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_turbo_dist_turbo_es2017-esm_js-8eb9b2209bcd.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-893f9f-cd5d89ebdb50.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_quote-selection_dist_index_js-node_modules_github_session-resume_-590a09-91fdc8802bfa.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/packages_document-metadata_document-metadata_ts-packages_failbot_failbot_ts-b8e9eefcce78.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/packages_updatable-content_updatable-content_ts-a743e72edcf2.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_ajax-error_ts-app_assets_modules_github_behaviors_details-6493f1-b7112815a1fc.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_task-list_ts-app_assets_modules_github_throttled-input_ts-047775-82bfe789bb2f.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_behaviors_commenting_edit_ts-app_assets_modules_github_behaviors_ht-83c235-6bc7a8849328.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/behaviors-6206313cbfca.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_delegated-events_dist_index_js-node_modules_github_catalyst_lib_index_js-ef6d0f-60422ea0562f.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/notifications-global-f5c28dea1388.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_index_js-node_modules_virtualized-list_es_inde-8b3def-5e84a4d714f0.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_github_catalyst_lib_index_-280e4f-77dbb2662f19.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_mini-throttle_dist_decorators_js-node_modules_delegated-events_di-e161aa-34194327b80d.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_scroll-anchoring_dist_scroll-anchoring_esm_js-node_modules_github_hydro--581846-4d52a4aed490.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_ref-selector_ts-98da180bcdc4.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/app_assets_modules_github_diffs_blob-lines_ts-app_assets_modules_github_diffs_linkable-line-n-db17fa-ef77e0d5d94c.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/diffs-474bc704e6da.js" defer="defer"></script>
+  
+  <script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/primer-react-68db5c96d18f.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/react-core-f6571bc10d64.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/react-lib-17ccbc80f53b.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/octicons-react-0f0d82031c98.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_emotion_is-prop-valid_dist_emotion-is-prop-valid_esm_js-node_modules_emo-1fff13-a67dacb6db80.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_tanstack_query-core_build_modern_mutation_js-node_modules_tanstack_query-9bf7e4-a1bacdef8ef2.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_tanstack_query-core_build_modern_queryClient_js-node_modules_tanstack_re-d87a32-ae1d44ebdc99.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_lit-labs_react_index_js-node_modules_primer_styled-react_dist_index_js-n-6066db-b92ee15c1e46.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/packages_notifications-subscriptions-menu_entry_ts-packages_promise-with-resolvers-polyfill_p-df0233-37157a955eee.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/notifications-subscriptions-menu-113a2e7708e8.js" defer="defer"></script>
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-react.ad9424369aeb6fec9e91.module.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/notifications-subscriptions-menu.44a4ce5e60cfd5c27b1a.module.css" />
+
+  <script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/wiki-bc67fb92a59b.js" defer="defer"></script>
+
+
+  <title>Create new page · kiooeht/ModTheSpire Wiki · GitHub</title>
+
+
+
+  <meta name="route-pattern" content="/:user_id/:repository/wiki/:id(.:format)" data-turbo-transient>
+  <meta name="route-controller" content="wiki" data-turbo-transient>
+  <meta name="route-action" content="show" data-turbo-transient>
+  <meta name="fetch-nonce" content="v2:e99ac516-3c43-0c63-3af0-706d3a96d1a7">
+
+    
+  <meta name="current-catalog-service-hash" content="27690012a2eb28b75d0bacab0f2c11870266e8db9e019fa71fea812b82397bd6">
+
+
+  <meta name="request-id" content="5736:1C9D14:821CB3:B2D6A4:68DAB90B" data-pjax-transient="true"/><meta name="html-safe-nonce" content="18fb66acae2c87081d8d2bdf91ed48ae6376c987d692d5cc7ede3f612a8dbed9" data-pjax-transient="true"/><meta name="visitor-payload" content="eyJyZWZlcnJlciI6IiIsInJlcXVlc3RfaWQiOiI1NzM2OjFDOUQxNDo4MjFDQjM6QjJENkE0OjY4REFCOTBCIiwidmlzaXRvcl9pZCI6Ijg5ODI5MTA1OTM2NzEwMTg3NjMiLCJyZWdpb25fZWRnZSI6ImlhZCIsInJlZ2lvbl9yZW5kZXIiOiJpYWQifQ==" data-pjax-transient="true"/><meta name="visitor-hmac" content="4198bb2cdde90c5f9f4ef1100df7996093f6e6eeb2854eb5f959b6e1ecd7ae28" data-pjax-transient="true"/>
+
+
+    <meta name="hovercard-subject-tag" content="repository:118042024" data-turbo-transient>
+
+
+  <meta name="github-keyboard-shortcuts" content="repository,copilot" data-turbo-transient="true" />
+  
+
+  <meta name="selected-link" value="repo_wiki" data-turbo-transient>
+  <link rel="assets" href="https://github.githubassets.com/">
+
+    <meta name="google-site-verification" content="Apib7-x98H0j5cPqHWwSMm6dNU4GmODRoqxLiDzdx9I">
+
+<meta name="octolytics-url" content="https://collector.github.com/github/collect" />
+
+  <meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/wiki/show" data-turbo-transient="true" />
+
+  
+
+
+
+
+    <meta name="user-login" content="">
+
+  
+
+    <meta name="viewport" content="width=device-width">
+
+    
+
+      <meta name="description" content="External mod loader for Slay The Spire. Contribute to kiooeht/ModTheSpire development by creating an account on GitHub.">
+
+      <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+
+    <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+    <meta property="fb:app_id" content="1401488693436528">
+    <meta name="apple-itunes-app" content="app-id=1477376905, app-argument=https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib" />
+
+      <meta name="twitter:image" content="https://opengraph.githubassets.com/dadfed42211a39c9345d80c64cbdad74a95d66684022aa81cc6e400d8205d3df/kiooeht/ModTheSpire" /><meta name="twitter:site" content="@github" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="Create new page · kiooeht/ModTheSpire Wiki" /><meta name="twitter:description" content="External mod loader for Slay The Spire. Contribute to kiooeht/ModTheSpire development by creating an account on GitHub." />
+  <meta property="og:image" content="https://opengraph.githubassets.com/dadfed42211a39c9345d80c64cbdad74a95d66684022aa81cc6e400d8205d3df/kiooeht/ModTheSpire" /><meta property="og:image:alt" content="External mod loader for Slay The Spire. Contribute to kiooeht/ModTheSpire development by creating an account on GitHub." /><meta property="og:image:width" content="1200" /><meta property="og:image:height" content="600" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="Create new page · kiooeht/ModTheSpire Wiki" /><meta property="og:url" content="https://github.com/kiooeht/ModTheSpire" /><meta property="og:description" content="External mod loader for Slay The Spire. Contribute to kiooeht/ModTheSpire development by creating an account on GitHub." />
+  
+
+
+
+
+      <meta name="hostname" content="github.com">
+
+
+
+        <meta name="expected-hostname" content="github.com">
+
+
+  <meta http-equiv="x-pjax-version" content="c1435ba49a2b37852e28531b7a4234b322a56c2964ff2107fbf4a265f790a31c" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-csp-version" content="c922ef32c4ab94f8b870c62883f3e41755ec705db76ec4efb0d343458f1e28c7" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-css-version" content="52346ecdf234263f0a160a1d59dfd68544fb261b3a40e29f8f2743954a4f97b7" data-turbo-track="reload">
+  <meta http-equiv="x-pjax-js-version" content="a792979b95f9fa28587439219f49ea517d3f0cc4968683133778bbff006dd10b" data-turbo-track="reload">
+
+  <meta name="turbo-cache-control" content="no-preview" data-turbo-transient="">
+
+      <meta name="go-import" content="github.com/kiooeht/ModTheSpire git https://github.com/kiooeht/ModTheSpire.git">
+
+  <meta name="octolytics-dimension-user_id" content="236842" /><meta name="octolytics-dimension-user_login" content="kiooeht" /><meta name="octolytics-dimension-repository_id" content="118042024" /><meta name="octolytics-dimension-repository_nwo" content="kiooeht/ModTheSpire" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="118042024" /><meta name="octolytics-dimension-repository_network_root_nwo" content="kiooeht/ModTheSpire" />
+
+
+
+    
+
+    <meta name="turbo-body-classes" content="logged-out env-production page-responsive">
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <meta name="release" content="87a93216832ffc78ebbfca74848f10541fd840b5">
+  <meta name="ui-target" content="full">
+
+  <link rel="mask-icon" href="https://github.githubassets.com/assets/pinned-octocat-093da3e6fa40.svg" color="#000000">
+  <link rel="alternate icon" class="js-site-favicon" type="image/png" href="https://github.githubassets.com/favicons/favicon.png">
+  <link rel="icon" class="js-site-favicon" type="image/svg+xml" href="https://github.githubassets.com/favicons/favicon.svg" data-base-href="https://github.githubassets.com/favicons/favicon">
+
+<meta name="theme-color" content="#1e2327">
+<meta name="color-scheme" content="light dark" />
+
+
+  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
+    <div data-turbo-body class="logged-out env-production page-responsive" style="word-wrap: break-word;">
+      
+
+
+
+    <div class="position-relative header-wrapper js-header-wrapper ">
+      <a href="#start-of-content" data-skip-target-assigned="false" class="px-2 py-4 color-bg-accent-emphasis color-fg-on-emphasis show-on-focus js-skip-to-content">Skip to content</a>
+
+      <span data-view-component="true" class="progress-pjax-loader Progress position-fixed width-full">
+    <span style="width: 0%;" data-view-component="true" class="Progress-item progress-pjax-loader-bar left-0 top-0 color-bg-accent-emphasis"></span>
+</span>      
+      
+      <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-react.ad9424369aeb6fec9e91.module.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/keyboard-shortcuts-dialog.2de9c7d6456a311fce49.module.css" />
+
+<react-partial
+  partial-name="keyboard-shortcuts-dialog"
+  data-ssr="false"
+  data-attempted-ssr="false"
+  data-react-profiling="false"
+>
+  
+  <script type="application/json" data-target="react-partial.embeddedData">{"props":{"docsUrl":"https://docs.github.com/get-started/accessibility/keyboard-shortcuts"}}</script>
+  <div data-target="react-partial.reactRoot"></div>
+</react-partial>
+
+
+
+
+
+      
+
+          
+
+              
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_gsap_index_js-23c9606618ce.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/vendors-node_modules_github_remote-form_dist_index_js-node_modules_delegated-events_dist_inde-94fd67-04dd9f3c4754.js" defer="defer"></script>
+<script crossorigin="anonymous" type="application/javascript" src="https://github.githubassets.com/assets/sessions-ac148cb2a2f3.js" defer="defer"></script>
+
+<header class="HeaderMktg header-logged-out js-details-container js-header Details f4 py-3" role="banner" data-is-top="true" data-color-mode=light data-light-theme=light data-dark-theme=dark>
+  <h2 class="sr-only">Navigation Menu</h2>
+
+  <button type="button" class="HeaderMktg-backdrop d-lg-none border-0 position-fixed top-0 left-0 width-full height-full js-details-target" aria-label="Toggle navigation">
+    <span class="d-none">Toggle navigation</span>
+  </button>
+
+  <div class="d-flex flex-column flex-lg-row flex-items-center px-3 px-md-4 px-lg-5 height-full position-relative z-1">
+    <div class="d-flex flex-justify-between flex-items-center width-full width-lg-auto">
+      <div class="flex-1">
+        <button aria-label="Toggle navigation" aria-expanded="false" type="button" data-view-component="true" class="js-details-target js-nav-padding-recalculate js-header-menu-toggle Button--link Button--medium Button d-lg-none color-fg-inherit p-1">  <span class="Button-content">
+    <span class="Button-label"><div class="HeaderMenu-toggle-bar rounded my-1"></div>
+            <div class="HeaderMenu-toggle-bar rounded my-1"></div>
+            <div class="HeaderMenu-toggle-bar rounded my-1"></div></span>
+  </span>
+</button>
+      </div>
+
+      <a class="mr-lg-3 color-fg-inherit flex-order-2 js-prevent-focus-on-mobile-nav"
+        href="/"
+        aria-label="Homepage"
+        data-analytics-event="{&quot;category&quot;:&quot;Marketing nav&quot;,&quot;action&quot;:&quot;click to go to homepage&quot;,&quot;label&quot;:&quot;ref_page:Marketing;ref_cta:Logomark;ref_loc:Header&quot;}">
+        <svg height="32" aria-hidden="true" viewBox="0 0 24 24" version="1.1" width="32" data-view-component="true" class="octicon octicon-mark-github">
+    <path d="M12 1C5.923 1 1 5.923 1 12c0 4.867 3.149 8.979 7.521 10.436.55.096.756-.233.756-.522 0-.262-.013-1.128-.013-2.049-2.764.509-3.479-.674-3.699-1.292-.124-.317-.66-1.293-1.127-1.554-.385-.207-.936-.715-.014-.729.866-.014 1.485.797 1.691 1.128.99 1.663 2.571 1.196 3.204.907.096-.715.385-1.196.701-1.471-2.448-.275-5.005-1.224-5.005-5.432 0-1.196.426-2.186 1.128-2.956-.111-.275-.496-1.402.11-2.915 0 0 .921-.288 3.024 1.128a10.193 10.193 0 0 1 2.75-.371c.936 0 1.871.123 2.75.371 2.104-1.43 3.025-1.128 3.025-1.128.605 1.513.221 2.64.111 2.915.701.77 1.127 1.747 1.127 2.956 0 4.222-2.571 5.157-5.019 5.432.399.344.743 1.004.743 2.035 0 1.471-.014 2.654-.014 3.025 0 .289.206.632.756.522C19.851 20.979 23 16.854 23 12c0-6.077-4.922-11-11-11Z"></path>
+</svg>
+      </a>
+
+      <div class="d-flex flex-1 flex-order-2 text-right d-lg-none gap-2 flex-justify-end">
+          <a
+            href="/login?return_to=https%3A%2F%2Fgithub.com%2Fkiooeht%2FModTheSpire%2Fwiki%2FStS-Lib"
+            class="HeaderMenu-link HeaderMenu-button d-inline-flex f5 no-underline border color-border-default rounded-2 px-2 py-1 color-fg-inherit js-prevent-focus-on-mobile-nav"
+            data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="bf9436b8e2e72d86f5bc0cbb673bd7cfd1d5965e463ba7714d028ed64a7820e5"
+            data-analytics-event="{&quot;category&quot;:&quot;Marketing nav&quot;,&quot;action&quot;:&quot;click to Sign in&quot;,&quot;label&quot;:&quot;ref_page:Marketing;ref_cta:Sign in;ref_loc:Header&quot;}"
+          >
+            Sign in
+          </a>
+              <div class="AppHeader-appearanceSettings">
+    <react-partial-anchor>
+      <button data-target="react-partial-anchor.anchor" id="icon-button-9445aa22-a21b-43ee-be31-8a21103a3dc2" aria-labelledby="tooltip-bc5fd159-79a3-4dc3-b469-c7472e1737b3" type="button" disabled="disabled" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium AppHeader-button HeaderMenu-link border cursor-wait">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-sliders Button-visual">
+    <path d="M15 2.75a.75.75 0 0 1-.75.75h-4a.75.75 0 0 1 0-1.5h4a.75.75 0 0 1 .75.75Zm-8.5.75v1.25a.75.75 0 0 0 1.5 0v-4a.75.75 0 0 0-1.5 0V2H1.75a.75.75 0 0 0 0 1.5H6.5Zm1.25 5.25a.75.75 0 0 0 0-1.5h-6a.75.75 0 0 0 0 1.5h6ZM15 8a.75.75 0 0 1-.75.75H11.5V10a.75.75 0 1 1-1.5 0V6a.75.75 0 0 1 1.5 0v1.25h2.75A.75.75 0 0 1 15 8Zm-9 5.25v-2a.75.75 0 0 0-1.5 0v1.25H1.75a.75.75 0 0 0 0 1.5H4.5v1.25a.75.75 0 0 0 1.5 0v-2Zm9 0a.75.75 0 0 1-.75.75h-6a.75.75 0 0 1 0-1.5h6a.75.75 0 0 1 .75.75Z"></path>
+</svg>
+</button><tool-tip id="tooltip-bc5fd159-79a3-4dc3-b469-c7472e1737b3" for="icon-button-9445aa22-a21b-43ee-be31-8a21103a3dc2" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Appearance settings</tool-tip>
+
+      <template data-target="react-partial-anchor.template">
+        <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-react.ad9424369aeb6fec9e91.module.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/appearance-settings.6c63a6de228d6520804d.module.css" />
+
+<react-partial
+  partial-name="appearance-settings"
+  data-ssr="false"
+  data-attempted-ssr="false"
+  data-react-profiling="false"
+>
+  
+  <script type="application/json" data-target="react-partial.embeddedData">{"props":{}}</script>
+  <div data-target="react-partial.reactRoot"></div>
+</react-partial>
+
+
+      </template>
+    </react-partial-anchor>
+  </div>
+
+      </div>
+    </div>
+
+
+    <div class="HeaderMenu js-header-menu height-fit position-lg-relative d-lg-flex flex-column flex-auto top-0">
+      <div class="HeaderMenu-wrapper d-flex flex-column flex-self-start flex-lg-row flex-auto rounded rounded-lg-0">
+          <nav class="HeaderMenu-nav" aria-label="Global">
+            <ul class="d-lg-flex list-style-none">
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Platform
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 pt-2 pt-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 dropdown-menu-wide">
+        <div class="d-lg-flex dropdown-menu-wide">
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="">
+
+                  <ul class="list-style-none f5" >
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_copilot&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_copilot_link_platform_navbar&quot;}" href="https://github.com/features/copilot">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-copilot color-fg-subtle mr-3">
+    <path d="M23.922 16.992c-.861 1.495-5.859 5.023-11.922 5.023-6.063 0-11.061-3.528-11.922-5.023A.641.641 0 0 1 0 16.736v-2.869a.841.841 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.195 10.195 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952 1.399-1.136 3.392-2.093 6.122-2.093 2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.832.832 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256ZM12.172 11h-.344a4.323 4.323 0 0 1-.355.508C10.703 12.455 9.555 13 7.965 13c-1.725 0-2.989-.359-3.782-1.259a2.005 2.005 0 0 1-.085-.104L4 11.741v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.323 4.323 0 0 1-.355-.508h-.016.016Zm.641-2.935c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z"></path><path d="M14.5 14.25a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Zm-5 0a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Copilot
+
+        </div>
+
+        Write better code with AI
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_spark&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_spark_link_platform_navbar&quot;}" href="https://github.com/features/spark">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-sparkle-fill color-fg-subtle mr-3">
+    <path d="M11.296 1.924c.24-.656 1.168-.656 1.408 0l.717 1.958a11.25 11.25 0 0 0 6.697 6.697l1.958.717c.657.24.657 1.168 0 1.408l-1.958.717a11.25 11.25 0 0 0-6.697 6.697l-.717 1.958c-.24.657-1.168.657-1.408 0l-.717-1.958a11.25 11.25 0 0 0-6.697-6.697l-1.958-.717c-.656-.24-.656-1.168 0-1.408l1.958-.717a11.25 11.25 0 0 0 6.697-6.697l.717-1.958Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Spark
+
+            <span class="HeaderMenu-label">
+              New
+            </span>
+        </div>
+
+        Build and deploy intelligent apps
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_models&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_models_link_platform_navbar&quot;}" href="https://github.com/features/models">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-ai-model color-fg-subtle mr-3">
+    <path d="M19.375 8.5a3.25 3.25 0 1 1-3.163 4h-3a3.252 3.252 0 0 1-4.443 2.509L7.214 17.76a3.25 3.25 0 1 1-1.342-.674l1.672-2.957A3.238 3.238 0 0 1 6.75 12c0-.907.371-1.727.97-2.316L6.117 6.846A3.253 3.253 0 0 1 1.875 3.75a3.25 3.25 0 1 1 5.526 2.32l1.603 2.836A3.25 3.25 0 0 1 13.093 11h3.119a3.252 3.252 0 0 1 3.163-2.5ZM10 10.25a1.75 1.75 0 1 0-.001 3.499A1.75 1.75 0 0 0 10 10.25ZM5.125 2a1.75 1.75 0 1 0 0 3.5 1.75 1.75 0 0 0 0-3.5Zm12.5 9.75a1.75 1.75 0 1 0 3.5 0 1.75 1.75 0 0 0-3.5 0Zm-14.25 8.5a1.75 1.75 0 1 0 3.501-.001 1.75 1.75 0 0 0-3.501.001Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Models
+
+            <span class="HeaderMenu-label">
+              New
+            </span>
+        </div>
+
+        Manage and compare prompts
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_advanced_security&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_advanced_security_link_platform_navbar&quot;}" href="https://github.com/security/advanced-security">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-shield-check color-fg-subtle mr-3">
+    <path d="M16.53 9.78a.75.75 0 0 0-1.06-1.06L11 13.19l-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5Z"></path><path d="m12.54.637 8.25 2.675A1.75 1.75 0 0 1 22 4.976V10c0 6.19-3.771 10.704-9.401 12.83a1.704 1.704 0 0 1-1.198 0C5.77 20.705 2 16.19 2 10V4.976c0-.758.489-1.43 1.21-1.664L11.46.637a1.748 1.748 0 0 1 1.08 0Zm-.617 1.426-8.25 2.676a.249.249 0 0 0-.173.237V10c0 5.46 3.28 9.483 8.43 11.426a.199.199 0 0 0 .14 0C17.22 19.483 20.5 15.461 20.5 10V4.976a.25.25 0 0 0-.173-.237l-8.25-2.676a.253.253 0 0 0-.154 0Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Advanced Security
+
+        </div>
+
+        Find and fix vulnerabilities
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;actions&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;actions_link_platform_navbar&quot;}" href="https://github.com/features/actions">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-workflow color-fg-subtle mr-3">
+    <path d="M1 3a2 2 0 0 1 2-2h6.5a2 2 0 0 1 2 2v6.5a2 2 0 0 1-2 2H7v4.063C7 16.355 7.644 17 8.438 17H12.5v-2.5a2 2 0 0 1 2-2H21a2 2 0 0 1 2 2V21a2 2 0 0 1-2 2h-6.5a2 2 0 0 1-2-2v-2.5H8.437A2.939 2.939 0 0 1 5.5 15.562V11.5H3a2 2 0 0 1-2-2Zm2-.5a.5.5 0 0 0-.5.5v6.5a.5.5 0 0 0 .5.5h6.5a.5.5 0 0 0 .5-.5V3a.5.5 0 0 0-.5-.5ZM14.5 14a.5.5 0 0 0-.5.5V21a.5.5 0 0 0 .5.5H21a.5.5 0 0 0 .5-.5v-6.5a.5.5 0 0 0-.5-.5Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Actions
+
+        </div>
+
+        Automate any workflow
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+            <div class="HeaderMenu-column px-lg-4 pb-3 pb-lg-0 border-lg-right">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                  <ul class="list-style-none f5" >
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;codespaces&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;codespaces_link_platform_navbar&quot;}" href="https://github.com/features/codespaces">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-codespaces color-fg-subtle mr-3">
+    <path d="M3.5 3.75C3.5 2.784 4.284 2 5.25 2h13.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 18.75 13H5.25a1.75 1.75 0 0 1-1.75-1.75Zm-2 12c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v4a1.75 1.75 0 0 1-1.75 1.75H3.25a1.75 1.75 0 0 1-1.75-1.75ZM5.25 3.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h13.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Zm-2 12a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h17.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25Z"></path><path d="M10 17.75a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Codespaces
+
+        </div>
+
+        Instant dev environments
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;issues&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;issues_link_platform_navbar&quot;}" href="https://github.com/features/issues">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-issue-opened color-fg-subtle mr-3">
+    <path d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1ZM2.5 12a9.5 9.5 0 0 0 9.5 9.5 9.5 9.5 0 0 0 9.5-9.5A9.5 9.5 0 0 0 12 2.5 9.5 9.5 0 0 0 2.5 12Zm9.5 2a2 2 0 1 1-.001-3.999A2 2 0 0 1 12 14Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Issues
+
+        </div>
+
+        Plan and track work
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;code_review&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;code_review_link_platform_navbar&quot;}" href="https://github.com/features/code-review">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-code-review color-fg-subtle mr-3">
+    <path d="M10.3 6.74a.75.75 0 0 1-.04 1.06l-2.908 2.7 2.908 2.7a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 0 1 1.06.04Zm3.44 1.06a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.908-2.7-2.908-2.7Z"></path><path d="M1.5 4.25c0-.966.784-1.75 1.75-1.75h17.5c.966 0 1.75.784 1.75 1.75v12.5a1.75 1.75 0 0 1-1.75 1.75h-9.69l-3.573 3.573A1.458 1.458 0 0 1 5 21.043V18.5H3.25a1.75 1.75 0 0 1-1.75-1.75ZM3.25 4a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h2.5a.75.75 0 0 1 .75.75v3.19l3.72-3.72a.749.749 0 0 1 .53-.22h10a.25.25 0 0 0 .25-.25V4.25a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Code Review
+
+        </div>
+
+        Manage code changes
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;discussions&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;discussions_link_platform_navbar&quot;}" href="https://github.com/features/discussions">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-comment-discussion color-fg-subtle mr-3">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 14.25 14H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 15.543V14H1.75A1.75 1.75 0 0 1 0 12.25v-9.5C0 1.784.784 1 1.75 1ZM1.5 2.75v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path><path d="M22.5 8.75a.25.25 0 0 0-.25-.25h-3.5a.75.75 0 0 1 0-1.5h3.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 22.25 20H21v1.543a1.457 1.457 0 0 1-2.487 1.03L15.939 20H10.75A1.75 1.75 0 0 1 9 18.25v-1.465a.75.75 0 0 1 1.5 0v1.465c0 .138.112.25.25.25h5.5a.75.75 0 0 1 .53.22l2.72 2.72v-2.19a.75.75 0 0 1 .75-.75h2a.25.25 0 0 0 .25-.25v-9.5Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Discussions
+
+        </div>
+
+        Collaborate outside of code
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;code_search&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;code_search_link_platform_navbar&quot;}" href="https://github.com/features/code-search">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-code-square color-fg-subtle mr-3">
+    <path d="M10.3 8.24a.75.75 0 0 1-.04 1.06L7.352 12l2.908 2.7a.75.75 0 1 1-1.02 1.1l-3.5-3.25a.75.75 0 0 1 0-1.1l3.5-3.25a.75.75 0 0 1 1.06.04Zm3.44 1.06a.75.75 0 1 1 1.02-1.1l3.5 3.25a.75.75 0 0 1 0 1.1l-3.5 3.25a.75.75 0 1 1-1.02-1.1l2.908-2.7-2.908-2.7Z"></path><path d="M2 3.75C2 2.784 2.784 2 3.75 2h16.5c.966 0 1.75.784 1.75 1.75v16.5A1.75 1.75 0 0 1 20.25 22H3.75A1.75 1.75 0 0 1 2 20.25Zm1.75-.25a.25.25 0 0 0-.25.25v16.5c0 .138.112.25.25.25h16.5a.25.25 0 0 0 .25-.25V3.75a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Code Search
+
+        </div>
+
+        Find more, search less
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 mb-3 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="platform-explore-heading">Explore</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="platform-explore-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;why_github&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;why_github_link_platform_navbar&quot;}" href="https://github.com/why-github">
+      Why GitHub
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary Link--external" target="_blank" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;documentation&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;documentation_link_platform_navbar&quot;}" href="https://docs.github.com">
+      Documentation
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary Link--external" target="_blank" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_skills&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_skills_link_platform_navbar&quot;}" href="https://skills.github.com">
+      GitHub Skills
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary Link--external" target="_blank" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;blog&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;blog_link_platform_navbar&quot;}" href="https://github.blog">
+      Blog
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                  </ul>
+                </div>
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="platform-integrations-heading">Integrations</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="platform-integrations-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_marketplace&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_marketplace_link_platform_navbar&quot;}" href="https://github.com/marketplace">
+      GitHub Marketplace
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;mcp_registry&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;mcp_registry_link_platform_navbar&quot;}" href="https://github.com/mcp">
+      MCP Registry
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+        </div>
+
+          <div class="HeaderMenu-trailing-link rounded-bottom-2 mt-lg-4 px-lg-4 py-4 py-lg-3 f5 text-semibold">
+            <a data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;view_all_features&quot;,&quot;context&quot;:&quot;platform&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;view_all_features_link_platform_navbar&quot;}" href="https://github.com/features">
+              View all features
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-right HeaderMenu-trailing-link-icon">
+    <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</a>          </div>
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Solutions
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 pt-2 pt-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 dropdown-menu-wide">
+        <div class="d-lg-flex dropdown-menu-wide">
+            <div class="HeaderMenu-column px-lg-4 pb-3 pb-lg-0 border-lg-right">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="solutions-by-company-size-heading">By company size</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="solutions-by-company-size-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;enterprises&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;enterprises_link_solutions_navbar&quot;}" href="https://github.com/enterprise">
+      Enterprises
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;small_and_medium_teams&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;small_and_medium_teams_link_solutions_navbar&quot;}" href="https://github.com/team">
+      Small and medium teams
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;startups&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;startups_link_solutions_navbar&quot;}" href="https://github.com/enterprise/startups">
+      Startups
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;nonprofits&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;nonprofits_link_solutions_navbar&quot;}" href="/solutions/industry/nonprofits">
+      Nonprofits
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+            <div class="HeaderMenu-column px-lg-4 pb-3 pb-lg-0 border-lg-right">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="solutions-by-use-case-heading">By use case</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="solutions-by-use-case-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;app_modernization&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;app_modernization_link_solutions_navbar&quot;}" href="/solutions/use-case/app-modernization">
+      App Modernization
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;devsecops&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;devsecops_link_solutions_navbar&quot;}" href="/solutions/use-case/devsecops">
+      DevSecOps
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;devops&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;devops_link_solutions_navbar&quot;}" href="/solutions/use-case/devops">
+      DevOps
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;ci_cd&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;ci_cd_link_solutions_navbar&quot;}" href="/solutions/use-case/ci-cd">
+      CI/CD
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;view_all_use_cases&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;view_all_use_cases_link_solutions_navbar&quot;}" href="/solutions/use-case">
+      View all use cases
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="solutions-by-industry-heading">By industry</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="solutions-by-industry-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;healthcare&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;healthcare_link_solutions_navbar&quot;}" href="/solutions/industry/healthcare">
+      Healthcare
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;financial_services&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;financial_services_link_solutions_navbar&quot;}" href="/solutions/industry/financial-services">
+      Financial services
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;manufacturing&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;manufacturing_link_solutions_navbar&quot;}" href="/solutions/industry/manufacturing">
+      Manufacturing
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;government&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;government_link_solutions_navbar&quot;}" href="/solutions/industry/government">
+      Government
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;view_all_industries&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;view_all_industries_link_solutions_navbar&quot;}" href="/solutions/industry">
+      View all industries
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+        </div>
+
+          <div class="HeaderMenu-trailing-link rounded-bottom-2 mt-lg-4 px-lg-4 py-4 py-lg-3 f5 text-semibold">
+            <a data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;view_all_solutions&quot;,&quot;context&quot;:&quot;solutions&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;view_all_solutions_link_solutions_navbar&quot;}" href="/solutions">
+              View all solutions
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-right HeaderMenu-trailing-link-icon">
+    <path d="M6.22 3.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L9.94 8 6.22 4.28a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</a>          </div>
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Resources
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 pt-2 pt-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 pb-2 pb-lg-4 dropdown-menu-wide">
+        <div class="d-lg-flex dropdown-menu-wide">
+            <div class="HeaderMenu-column px-lg-4 pb-3 pb-lg-0 border-lg-right">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 pb-3">
+
+                      <span class="d-block h4 color-fg-default my-1" id="resources-topics-heading">Topics</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="resources-topics-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;ai&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;ai_link_resources_navbar&quot;}" href="/resources/articles/ai">
+      AI
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;devops&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;devops_link_resources_navbar&quot;}" href="/resources/articles/devops">
+      DevOps
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;security&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;security_link_resources_navbar&quot;}" href="/resources/articles/security">
+      Security
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;software_development&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;software_development_link_resources_navbar&quot;}" href="/resources/articles/software-development">
+      Software Development
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;view_all&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;view_all_link_resources_navbar&quot;}" href="/resources/articles">
+      View all
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="border-bottom border-lg-bottom-0 pb-lg-0 border-bottom-0">
+
+                      <span class="d-block h4 color-fg-default my-1" id="resources-explore-heading">Explore</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="resources-explore-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary Link--external" target="_blank" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;learning_pathways&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;learning_pathways_link_resources_navbar&quot;}" href="https://resources.github.com/learn/pathways">
+      Learning Pathways
+
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link-external HeaderMenu-external-icon color-fg-subtle">
+    <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-3.5a.25.25 0 0 0-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-3.5a.75.75 0 0 1 1.5 0v3.5A1.75 1.75 0 0 1 12.25 14h-8.5A1.75 1.75 0 0 1 2 12.25v-8.5C2 2.784 2.784 2 3.75 2Zm6.854-1h4.146a.25.25 0 0 1 .25.25v4.146a.25.25 0 0 1-.427.177L13.03 4.03 9.28 7.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.75-3.75-1.543-1.543A.25.25 0 0 1 10.604 1Z"></path>
+</svg>
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;events_amp_webinars&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;events_amp_webinars_link_resources_navbar&quot;}" href="https://github.com/resources/events">
+      Events &amp; Webinars
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;ebooks_amp_whitepapers&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;ebooks_amp_whitepapers_link_resources_navbar&quot;}" href="https://github.com/resources/whitepapers">
+      Ebooks &amp; Whitepapers
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;customer_stories&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;customer_stories_link_resources_navbar&quot;}" href="https://github.com/customer-stories">
+      Customer Stories
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;partners&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;partners_link_resources_navbar&quot;}" href="https://github.com/partners">
+      Partners
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;executive_insights&quot;,&quot;context&quot;:&quot;resources&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;executive_insights_link_resources_navbar&quot;}" href="https://github.com/solutions/executive-insights">
+      Executive Insights
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+        </div>
+
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Open Source
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 pt-2 pt-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 pb-2 pb-lg-4">
+        <div class="d-lg-flex dropdown-menu-wide">
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="border-bottom mb-3 mb-lg-3 pb-3">
+
+                  <ul class="list-style-none f5" >
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_sponsors&quot;,&quot;context&quot;:&quot;open_source&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_sponsors_link_open_source_navbar&quot;}" href="/sponsors">
+      
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Sponsors
+
+        </div>
+
+        Fund open source developers
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+                <div class="border-bottom mb-3 mb-lg-3 pb-3">
+
+                  <ul class="list-style-none f5" >
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;the_readme_project&quot;,&quot;context&quot;:&quot;open_source&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;the_readme_project_link_open_source_navbar&quot;}" href="https://github.com/readme">
+      
+      <div>
+        <div class="color-fg-default h4">
+          The ReadME Project
+
+        </div>
+
+        GitHub community articles
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+                <div class="border-bottom border-bottom-0">
+
+                      <span class="d-block h4 color-fg-default my-1" id="open-source-repositories-heading">Repositories</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="open-source-repositories-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;topics&quot;,&quot;context&quot;:&quot;open_source&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;topics_link_open_source_navbar&quot;}" href="https://github.com/topics">
+      Topics
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;trending&quot;,&quot;context&quot;:&quot;open_source&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;trending_link_open_source_navbar&quot;}" href="https://github.com/trending">
+      Trending
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;collections&quot;,&quot;context&quot;:&quot;open_source&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;collections_link_open_source_navbar&quot;}" href="https://github.com/collections">
+      Collections
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+        </div>
+
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+      <button type="button" class="HeaderMenu-link border-0 width-full width-lg-auto px-0 px-lg-2 py-lg-2 no-wrap d-flex flex-items-center flex-justify-between js-details-target" aria-expanded="false">
+        Enterprise
+        <svg opacity="0.5" aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-chevron-down HeaderMenu-icon ml-1">
+    <path d="M12.78 5.22a.749.749 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.06 0L3.22 6.28a.749.749 0 1 1 1.06-1.06L8 8.939l3.72-3.719a.749.749 0 0 1 1.06 0Z"></path>
+</svg>
+      </button>
+
+      <div class="HeaderMenu-dropdown dropdown-menu rounded m-0 p-0 pt-2 pt-lg-4 position-relative position-lg-absolute left-0 left-lg-n3 pb-2 pb-lg-4">
+        <div class="d-lg-flex dropdown-menu-wide">
+            <div class="HeaderMenu-column px-lg-4">
+                <div class="border-bottom mb-3 mb-lg-3 pb-3">
+
+                  <ul class="list-style-none f5" >
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;enterprise_platform&quot;,&quot;context&quot;:&quot;enterprise&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;enterprise_platform_link_enterprise_navbar&quot;}" href="/enterprise">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-stack color-fg-subtle mr-3">
+    <path d="M11.063 1.456a1.749 1.749 0 0 1 1.874 0l8.383 5.316a1.751 1.751 0 0 1 0 2.956l-8.383 5.316a1.749 1.749 0 0 1-1.874 0L2.68 9.728a1.751 1.751 0 0 1 0-2.956Zm1.071 1.267a.25.25 0 0 0-.268 0L3.483 8.039a.25.25 0 0 0 0 .422l8.383 5.316a.25.25 0 0 0 .268 0l8.383-5.316a.25.25 0 0 0 0-.422Z"></path><path d="M1.867 12.324a.75.75 0 0 1 1.035-.232l8.964 5.685a.25.25 0 0 0 .268 0l8.964-5.685a.75.75 0 0 1 .804 1.267l-8.965 5.685a1.749 1.749 0 0 1-1.874 0l-8.965-5.685a.75.75 0 0 1-.231-1.035Z"></path><path d="M1.867 16.324a.75.75 0 0 1 1.035-.232l8.964 5.685a.25.25 0 0 0 .268 0l8.964-5.685a.75.75 0 0 1 .804 1.267l-8.965 5.685a1.749 1.749 0 0 1-1.874 0l-8.965-5.685a.75.75 0 0 1-.231-1.035Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Enterprise platform
+
+        </div>
+
+        AI-powered developer platform
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+                <div class="border-bottom border-bottom-0">
+
+                      <span class="d-block h4 color-fg-default my-1" id="enterprise-available-add-ons-heading">Available add-ons</span>
+
+                  <ul class="list-style-none f5" aria-labelledby="enterprise-available-add-ons-heading">
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;github_advanced_security&quot;,&quot;context&quot;:&quot;enterprise&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;github_advanced_security_link_enterprise_navbar&quot;}" href="https://github.com/security/advanced-security">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-shield-check color-fg-subtle mr-3">
+    <path d="M16.53 9.78a.75.75 0 0 0-1.06-1.06L11 13.19l-1.97-1.97a.75.75 0 0 0-1.06 1.06l2.5 2.5a.75.75 0 0 0 1.06 0l5-5Z"></path><path d="m12.54.637 8.25 2.675A1.75 1.75 0 0 1 22 4.976V10c0 6.19-3.771 10.704-9.401 12.83a1.704 1.704 0 0 1-1.198 0C5.77 20.705 2 16.19 2 10V4.976c0-.758.489-1.43 1.21-1.664L11.46.637a1.748 1.748 0 0 1 1.08 0Zm-.617 1.426-8.25 2.676a.249.249 0 0 0-.173.237V10c0 5.46 3.28 9.483 8.43 11.426a.199.199 0 0 0 .14 0C17.22 19.483 20.5 15.461 20.5 10V4.976a.25.25 0 0 0-.173-.237l-8.25-2.676a.253.253 0 0 0-.154 0Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          GitHub Advanced Security
+
+        </div>
+
+        Enterprise-grade security features
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description mb-lg-3" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;copilot_for_business&quot;,&quot;context&quot;:&quot;enterprise&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;copilot_for_business_link_enterprise_navbar&quot;}" href="/features/copilot/copilot-business">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-copilot color-fg-subtle mr-3">
+    <path d="M23.922 16.992c-.861 1.495-5.859 5.023-11.922 5.023-6.063 0-11.061-3.528-11.922-5.023A.641.641 0 0 1 0 16.736v-2.869a.841.841 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.195 10.195 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952 1.399-1.136 3.392-2.093 6.122-2.093 2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.832.832 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256ZM12.172 11h-.344a4.323 4.323 0 0 1-.355.508C10.703 12.455 9.555 13 7.965 13c-1.725 0-2.989-.359-3.782-1.259a2.005 2.005 0 0 1-.085-.104L4 11.741v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.323 4.323 0 0 1-.355-.508h-.016.016Zm.641-2.935c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z"></path><path d="M14.5 14.25a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Zm-5 0a1 1 0 0 1 1 1v2a1 1 0 0 1-2 0v-2a1 1 0 0 1 1-1Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Copilot for business
+
+        </div>
+
+        Enterprise-grade AI features
+      </div>
+
+    
+</a></li>
+
+                      <li>
+  <a class="HeaderMenu-dropdown-link d-block no-underline position-relative py-2 Link--secondary d-flex flex-items-center Link--has-description" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;premium_support&quot;,&quot;context&quot;:&quot;enterprise&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;premium_support_link_enterprise_navbar&quot;}" href="/premium-support">
+      <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-comment-discussion color-fg-subtle mr-3">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 14.25 14H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 15.543V14H1.75A1.75 1.75 0 0 1 0 12.25v-9.5C0 1.784.784 1 1.75 1ZM1.5 2.75v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Z"></path><path d="M22.5 8.75a.25.25 0 0 0-.25-.25h-3.5a.75.75 0 0 1 0-1.5h3.5c.966 0 1.75.784 1.75 1.75v9.5A1.75 1.75 0 0 1 22.25 20H21v1.543a1.457 1.457 0 0 1-2.487 1.03L15.939 20H10.75A1.75 1.75 0 0 1 9 18.25v-1.465a.75.75 0 0 1 1.5 0v1.465c0 .138.112.25.25.25h5.5a.75.75 0 0 1 .53.22l2.72 2.72v-2.19a.75.75 0 0 1 .75-.75h2a.25.25 0 0 0 .25-.25v-9.5Z"></path>
+</svg>
+      <div>
+        <div class="color-fg-default h4">
+          Premium Support
+
+        </div>
+
+        Enterprise-grade 24/7 support
+      </div>
+
+    
+</a></li>
+
+                  </ul>
+                </div>
+            </div>
+        </div>
+
+      </div>
+</li>
+
+
+                <li class="HeaderMenu-item position-relative flex-wrap flex-justify-between flex-items-center d-block d-lg-flex flex-lg-nowrap flex-lg-items-center js-details-container js-header-menu-item">
+    <a class="HeaderMenu-link no-underline px-0 px-lg-2 py-3 py-lg-2 d-block d-lg-inline-block" data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;platform&quot;,&quot;context&quot;:&quot;global&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;platform_link_global_navbar&quot;}" href="https://github.com/pricing">Pricing</a>
+</li>
+
+            </ul>
+          </nav>
+
+        <div class="d-flex flex-column flex-lg-row width-full flex-justify-end flex-lg-items-center text-center mt-3 mt-lg-0 text-lg-left ml-lg-3">
+                
+
+
+<qbsearch-input class="search-input" data-scope="repo:kiooeht/ModTheSpire" data-custom-scopes-path="/search/custom_scopes" data-delete-custom-scopes-csrf="91qY3dn7_UGnEFsC4ZSMDBW7NiT2MdRiRRteHyYPcS40Goce5ZSpLeYVInc1cW5VwfTvKRvS5lePelwK2SvJRg" data-max-custom-scopes="10" data-header-redesign-enabled="false" data-initial-value="" data-blackbird-suggestions-path="/search/suggestions" data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations" data-current-repository="kiooeht/ModTheSpire" data-current-org="" data-current-owner="kiooeht" data-logged-in="false" data-copilot-chat-enabled="false" data-nl-search-enabled="false" data-retain-scroll-position="true">
+  <div
+    class="search-input-container search-with-dialog position-relative d-flex flex-row flex-items-center mr-4 rounded"
+    data-action="click:qbsearch-input#searchInputContainerClicked"
+  >
+      <button
+        type="button"
+        class="header-search-button placeholder  input-button form-control d-flex flex-1 flex-self-stretch flex-items-center no-wrap width-full py-0 pl-2 pr-0 text-left border-0 box-shadow-none"
+        data-target="qbsearch-input.inputButton"
+        aria-label="Search or jump to…"
+        aria-haspopup="dialog"
+        placeholder="Search or jump to..."
+        data-hotkey=s,/
+        autocapitalize="off"
+        data-analytics-event="{&quot;location&quot;:&quot;navbar&quot;,&quot;action&quot;:&quot;searchbar&quot;,&quot;context&quot;:&quot;global&quot;,&quot;tag&quot;:&quot;input&quot;,&quot;label&quot;:&quot;searchbar_input_global_navbar&quot;}"
+        data-action="click:qbsearch-input#handleExpand"
+      >
+        <div class="mr-2 color-fg-muted">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+        </div>
+        <span class="flex-1" data-target="qbsearch-input.inputButtonText">Search or jump to...</span>
+          <div class="d-flex" data-target="qbsearch-input.hotkeyIndicator">
+            <svg xmlns="http://www.w3.org/2000/svg" width="22" height="20" aria-hidden="true" class="mr-1"><path fill="none" stroke="#979A9C" opacity=".4" d="M3.5.5h12c1.7 0 3 1.3 3 3v13c0 1.7-1.3 3-3 3h-12c-1.7 0-3-1.3-3-3v-13c0-1.7 1.3-3 3-3z"></path><path fill="#979A9C" d="M11.8 6L8 15.1h-.9L10.8 6h1z"></path></svg>
+          </div>
+      </button>
+
+    <input type="hidden" name="type" class="js-site-search-type-field">
+
+    
+<div class="Overlay--hidden " data-modal-dialog-overlay>
+  <modal-dialog data-action="close:qbsearch-input#handleClose cancel:qbsearch-input#handleClose" data-target="qbsearch-input.searchSuggestionsDialog" role="dialog" id="search-suggestions-dialog" aria-modal="true" aria-labelledby="search-suggestions-dialog-header" data-view-component="true" class="Overlay Overlay--width-large Overlay--height-auto">
+      <h1 id="search-suggestions-dialog-header" class="sr-only">Search code, repositories, users, issues, pull requests...</h1>
+    <div class="Overlay-body Overlay-body--paddingNone">
+      
+          <div data-view-component="true">        <div class="search-suggestions position-fixed width-full color-shadow-large border color-fg-default color-bg-default overflow-hidden d-flex flex-column query-builder-container"
+          style="border-radius: 12px;"
+          data-target="qbsearch-input.queryBuilderContainer"
+          hidden
+        >
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="query-builder-test-form" action="" accept-charset="UTF-8" method="get">
+  <query-builder data-target="qbsearch-input.queryBuilder" id="query-builder-query-builder-test" data-filter-key=":" data-view-component="true" class="QueryBuilder search-query-builder">
+    <div class="FormControl FormControl--fullWidth">
+      <label id="query-builder-test-label" for="query-builder-test" class="FormControl-label sr-only">
+        Search
+      </label>
+      <div
+        class="QueryBuilder-StyledInput width-fit "
+        data-target="query-builder.styledInput"
+      >
+          <span id="query-builder-test-leadingvisual-wrap" class="FormControl-input-leadingVisualWrap QueryBuilder-leadingVisualWrap">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search FormControl-input-leadingVisual">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+          </span>
+        <div data-target="query-builder.styledInputContainer" class="QueryBuilder-StyledInputContainer">
+          <div
+            aria-hidden="true"
+            class="QueryBuilder-StyledInputContent"
+            data-target="query-builder.styledInputContent"
+          ></div>
+          <div class="QueryBuilder-InputWrapper">
+            <div aria-hidden="true" class="QueryBuilder-Sizer" data-target="query-builder.sizer"></div>
+            <input id="query-builder-test" name="query-builder-test" value="" autocomplete="off" type="text" role="combobox" spellcheck="false" aria-expanded="false" aria-describedby="validation-8701647c-c135-4587-a201-f1f4ffc180e5" data-target="query-builder.input" data-action="
+          input:query-builder#inputChange
+          blur:query-builder#inputBlur
+          keydown:query-builder#inputKeydown
+          focus:query-builder#inputFocus
+        " data-view-component="true" class="FormControl-input QueryBuilder-Input FormControl-medium" />
+          </div>
+        </div>
+          <span class="sr-only" id="query-builder-test-clear">Clear</span>
+          <button role="button" id="query-builder-test-clear-button" aria-labelledby="query-builder-test-clear query-builder-test-label" data-target="query-builder.clearButton" data-action="
+                click:query-builder#clear
+                focus:query-builder#clearButtonFocus
+                blur:query-builder#clearButtonBlur
+              " variant="small" hidden="hidden" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium mr-1 px-2 py-0 d-flex flex-items-center rounded-1 color-fg-muted">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x-circle-fill Button-visual">
+    <path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.042.018.751.751 0 0 0-.018 1.042L6.94 8 4.97 9.97a.749.749 0 0 0 .326 1.275.749.749 0 0 0 .734-.215L8 9.06l1.97 1.97a.749.749 0 0 0 1.275-.326.749.749 0 0 0-.215-.734L9.06 8l1.97-1.97a.749.749 0 0 0-.326-1.275.749.749 0 0 0-.734.215L8 6.94Z"></path>
+</svg>
+</button>
+
+      </div>
+      <template id="search-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-search">
+    <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z"></path>
+</svg>
+</template>
+
+<template id="code-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</template>
+
+<template id="file-code-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-file-code">
+    <path d="M4 1.75C4 .784 4.784 0 5.75 0h5.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 14.25 15h-9a.75.75 0 0 1 0-1.5h9a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 10 4.25V1.5H5.75a.25.25 0 0 0-.25.25v2.5a.75.75 0 0 1-1.5 0Zm1.72 4.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.47-1.47-1.47-1.47a.75.75 0 0 1 0-1.06ZM3.28 7.78 1.81 9.25l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Zm8.22-6.218V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
+</svg>
+</template>
+
+<template id="history-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-history">
+    <path d="m.427 1.927 1.215 1.215a8.002 8.002 0 1 1-1.6 5.685.75.75 0 1 1 1.493-.154 6.5 6.5 0 1 0 1.18-4.458l1.358 1.358A.25.25 0 0 1 3.896 6H.25A.25.25 0 0 1 0 5.75V2.104a.25.25 0 0 1 .427-.177ZM7.75 4a.75.75 0 0 1 .75.75v2.992l2.028.812a.75.75 0 0 1-.557 1.392l-2.5-1A.751.751 0 0 1 7 8.25v-3.5A.75.75 0 0 1 7.75 4Z"></path>
+</svg>
+</template>
+
+<template id="repo-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo">
+    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
+</svg>
+</template>
+
+<template id="bookmark-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bookmark">
+    <path d="M3 2.75C3 1.784 3.784 1 4.75 1h6.5c.966 0 1.75.784 1.75 1.75v11.5a.75.75 0 0 1-1.227.579L8 11.722l-3.773 3.107A.751.751 0 0 1 3 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.91l3.023-2.489a.75.75 0 0 1 .954 0l3.023 2.49V2.75a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="plus-circle-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-plus-circle">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm7.25-3.25v2.5h2.5a.75.75 0 0 1 0 1.5h-2.5v2.5a.75.75 0 0 1-1.5 0v-2.5h-2.5a.75.75 0 0 1 0-1.5h2.5v-2.5a.75.75 0 0 1 1.5 0Z"></path>
+</svg>
+</template>
+
+<template id="circle-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-dot-fill">
+    <path d="M8 4a4 4 0 1 1 0 8 4 4 0 0 1 0-8Z"></path>
+</svg>
+</template>
+
+<template id="trash-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-trash">
+    <path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z"></path>
+</svg>
+</template>
+
+<template id="team-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-people">
+    <path d="M2 5.5a3.5 3.5 0 1 1 5.898 2.549 5.508 5.508 0 0 1 3.034 4.084.75.75 0 1 1-1.482.235 4 4 0 0 0-7.9 0 .75.75 0 0 1-1.482-.236A5.507 5.507 0 0 1 3.102 8.05 3.493 3.493 0 0 1 2 5.5ZM11 4a3.001 3.001 0 0 1 2.22 5.018 5.01 5.01 0 0 1 2.56 3.012.749.749 0 0 1-.885.954.752.752 0 0 1-.549-.514 3.507 3.507 0 0 0-2.522-2.372.75.75 0 0 1-.574-.73v-.352a.75.75 0 0 1 .416-.672A1.5 1.5 0 0 0 11 5.5.75.75 0 0 1 11 4Zm-5.5-.5a2 2 0 1 0-.001 3.999A2 2 0 0 0 5.5 3.5Z"></path>
+</svg>
+</template>
+
+<template id="project-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-project">
+    <path d="M1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0ZM1.5 1.75v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM11.75 3a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-1.5 0v-7.5a.75.75 0 0 1 .75-.75Zm-8.25.75a.75.75 0 0 1 1.5 0v5.5a.75.75 0 0 1-1.5 0ZM8 3a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 3Z"></path>
+</svg>
+</template>
+
+<template id="pencil-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-pencil">
+    <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"></path>
+</svg>
+</template>
+
+<template id="copilot-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copilot">
+    <path d="M7.998 15.035c-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.201-.508-.254-1.084-.254-1.656 0-.87.128-1.769.693-2.484.579-.733 1.494-1.124 2.724-1.261 1.206-.134 2.262.034 2.944.765.05.053.096.108.139.165.044-.057.094-.112.143-.165.682-.731 1.738-.899 2.944-.765 1.23.137 2.145.528 2.724 1.261.566.715.693 1.614.693 2.484 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095v1.872c0 .766-3.351 3.795-8.002 3.795Zm0-1.485c2.28 0 4.584-1.11 5.002-1.433V7.862l-.023-.116c-.49.21-1.075.291-1.727.291-1.146 0-2.059-.327-2.71-.991A3.222 3.222 0 0 1 8 6.303a3.24 3.24 0 0 1-.544.743c-.65.664-1.563.991-2.71.991-.652 0-1.236-.081-1.727-.291l-.023.116v4.255c.419.323 2.722 1.433 5.002 1.433ZM6.762 2.83c-.193-.206-.637-.413-1.682-.297-1.019.113-1.479.404-1.713.7-.247.312-.369.789-.369 1.554 0 .793.129 1.171.308 1.371.162.181.519.379 1.442.379.853 0 1.339-.235 1.638-.54.315-.322.527-.827.617-1.553.117-.935-.037-1.395-.241-1.614Zm4.155-.297c-1.044-.116-1.488.091-1.681.297-.204.219-.359.679-.242 1.614.091.726.303 1.231.618 1.553.299.305.784.54 1.638.54.922 0 1.28-.198 1.442-.379.179-.2.308-.578.308-1.371 0-.765-.123-1.242-.37-1.554-.233-.296-.693-.587-1.713-.7Z"></path><path d="M6.25 9.037a.75.75 0 0 1 .75.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 .75-.75Zm4.25.75v1.501a.75.75 0 0 1-1.5 0V9.787a.75.75 0 0 1 1.5 0Z"></path>
+</svg>
+</template>
+
+<template id="copilot-error-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copilot-error">
+    <path d="M16 11.24c0 .112-.072.274-.21.467L13 9.688V7.862l-.023-.116c-.49.21-1.075.291-1.727.291-.198 0-.388-.009-.571-.029L6.833 5.226a4.01 4.01 0 0 0 .17-.782c.117-.935-.037-1.395-.241-1.614-.193-.206-.637-.413-1.682-.297-.683.076-1.115.231-1.395.415l-1.257-.91c.579-.564 1.413-.877 2.485-.996 1.206-.134 2.262.034 2.944.765.05.053.096.108.139.165.044-.057.094-.112.143-.165.682-.731 1.738-.899 2.944-.765 1.23.137 2.145.528 2.724 1.261.566.715.693 1.614.693 2.484 0 .572-.053 1.148-.254 1.656.066.228.098.429.126.612.012.076.024.148.037.218.924.385 1.522 1.471 1.591 2.095Zm-5.083-8.707c-1.044-.116-1.488.091-1.681.297-.204.219-.359.679-.242 1.614.091.726.303 1.231.618 1.553.299.305.784.54 1.638.54.922 0 1.28-.198 1.442-.379.179-.2.308-.578.308-1.371 0-.765-.123-1.242-.37-1.554-.233-.296-.693-.587-1.713-.7Zm2.511 11.074c-1.393.776-3.272 1.428-5.43 1.428-4.562 0-7.873-2.914-7.998-3.749V9.338c.085-.628.677-1.686 1.588-2.065.013-.07.024-.143.036-.218.029-.183.06-.384.126-.612-.18-.455-.241-.963-.252-1.475L.31 4.107A.747.747 0 0 1 0 3.509V3.49a.748.748 0 0 1 .625-.73c.156-.026.306.047.435.139l14.667 10.578a.592.592 0 0 1 .227.264.752.752 0 0 1 .046.249v.022a.75.75 0 0 1-1.19.596Zm-1.367-.991L5.635 7.964a5.128 5.128 0 0 1-.889.073c-.652 0-1.236-.081-1.727-.291l-.023.116v4.255c.419.323 2.722 1.433 5.002 1.433 1.539 0 3.089-.505 4.063-.934Z"></path>
+</svg>
+</template>
+
+<template id="workflow-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-workflow">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h3.5C6.216 0 7 .784 7 1.75v3.5A1.75 1.75 0 0 1 5.25 7H4v4a1 1 0 0 0 1 1h4v-1.25C9 9.784 9.784 9 10.75 9h3.5c.966 0 1.75.784 1.75 1.75v3.5A1.75 1.75 0 0 1 14.25 16h-3.5A1.75 1.75 0 0 1 9 14.25v-.75H5A2.5 2.5 0 0 1 2.5 11V7h-.75A1.75 1.75 0 0 1 0 5.25Zm1.75-.25a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Zm9 9a.25.25 0 0 0-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 0 0 .25-.25v-3.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="book-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+</template>
+
+<template id="code-review-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-review">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 13H8.061l-2.574 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25v-8.5C0 1.784.784 1 1.75 1ZM1.5 2.75v8.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-8.5a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm5.28 1.72a.75.75 0 0 1 0 1.06L5.31 7l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.75.75 0 0 1 1.06 0Zm2.44 0a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L10.69 7 9.22 5.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</template>
+
+<template id="codespaces-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-codespaces">
+    <path d="M0 11.25c0-.966.784-1.75 1.75-1.75h12.5c.966 0 1.75.784 1.75 1.75v3A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm2-9.5C2 .784 2.784 0 3.75 0h8.5C13.216 0 14 .784 14 1.75v5a1.75 1.75 0 0 1-1.75 1.75h-8.5A1.75 1.75 0 0 1 2 6.75Zm1.75-.25a.25.25 0 0 0-.25.25v5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25v-5a.25.25 0 0 0-.25-.25Zm-2 9.5a.25.25 0 0 0-.25.25v3c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-3a.25.25 0 0 0-.25-.25Z"></path><path d="M7 12.75a.75.75 0 0 1 .75-.75h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1-.75-.75Zm-4 0a.75.75 0 0 1 .75-.75h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1-.75-.75Z"></path>
+</svg>
+</template>
+
+<template id="comment-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment">
+    <path d="M1 2.75C1 1.784 1.784 1 2.75 1h10.5c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 13.25 12H9.06l-2.573 2.573A1.458 1.458 0 0 1 4 13.543V12H2.75A1.75 1.75 0 0 1 1 10.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h4.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+</template>
+
+<template id="comment-discussion-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-comment-discussion">
+    <path d="M1.75 1h8.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 10.25 10H7.061l-2.574 2.573A1.458 1.458 0 0 1 2 11.543V10h-.25A1.75 1.75 0 0 1 0 8.25v-5.5C0 1.784.784 1 1.75 1ZM1.5 2.75v5.5c0 .138.112.25.25.25h1a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h3.5a.25.25 0 0 0 .25-.25v-5.5a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25Zm13 2a.25.25 0 0 0-.25-.25h-.5a.75.75 0 0 1 0-1.5h.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0 1 14.25 12H14v1.543a1.458 1.458 0 0 1-2.487 1.03L9.22 12.28a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l2.22 2.22v-2.19a.75.75 0 0 1 .75-.75h1a.25.25 0 0 0 .25-.25Z"></path>
+</svg>
+</template>
+
+<template id="organization-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-organization">
+    <path d="M1.75 16A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0h8.5C11.216 0 12 .784 12 1.75v12.5c0 .085-.006.168-.018.25h2.268a.25.25 0 0 0 .25-.25V8.285a.25.25 0 0 0-.111-.208l-1.055-.703a.749.749 0 1 1 .832-1.248l1.055.703c.487.325.779.871.779 1.456v5.965A1.75 1.75 0 0 1 14.25 16h-3.5a.766.766 0 0 1-.197-.026c-.099.017-.2.026-.303.026h-3a.75.75 0 0 1-.75-.75V14h-1v1.25a.75.75 0 0 1-.75.75Zm-.25-1.75c0 .138.112.25.25.25H4v-1.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 .75.75v1.25h2.25a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM3.75 6h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 3.75A.75.75 0 0 1 3.75 3h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 3.75Zm4 3A.75.75 0 0 1 7.75 6h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 7 6.75ZM7.75 3h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5ZM3 9.75A.75.75 0 0 1 3.75 9h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 9.75ZM7.75 9h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
+</svg>
+</template>
+
+<template id="rocket-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-rocket">
+    <path d="M14.064 0h.186C15.216 0 16 .784 16 1.75v.186a8.752 8.752 0 0 1-2.564 6.186l-.458.459c-.314.314-.641.616-.979.904v3.207c0 .608-.315 1.172-.833 1.49l-2.774 1.707a.749.749 0 0 1-1.11-.418l-.954-3.102a1.214 1.214 0 0 1-.145-.125L3.754 9.816a1.218 1.218 0 0 1-.124-.145L.528 8.717a.749.749 0 0 1-.418-1.11l1.71-2.774A1.748 1.748 0 0 1 3.31 4h3.204c.288-.338.59-.665.904-.979l.459-.458A8.749 8.749 0 0 1 14.064 0ZM8.938 3.623h-.002l-.458.458c-.76.76-1.437 1.598-2.02 2.5l-1.5 2.317 2.143 2.143 2.317-1.5c.902-.583 1.74-1.26 2.499-2.02l.459-.458a7.25 7.25 0 0 0 2.123-5.127V1.75a.25.25 0 0 0-.25-.25h-.186a7.249 7.249 0 0 0-5.125 2.123ZM3.56 14.56c-.732.732-2.334 1.045-3.005 1.148a.234.234 0 0 1-.201-.064.234.234 0 0 1-.064-.201c.103-.671.416-2.273 1.15-3.003a1.502 1.502 0 1 1 2.12 2.12Zm6.94-3.935c-.088.06-.177.118-.266.175l-2.35 1.521.548 1.783 1.949-1.2a.25.25 0 0 0 .119-.213ZM3.678 8.116 5.2 5.766c.058-.09.117-.178.176-.266H3.309a.25.25 0 0 0-.213.119l-1.2 1.95ZM12 5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+</template>
+
+<template id="shield-check-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield-check">
+    <path d="m8.533.133 5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667l5.25-1.68a1.748 1.748 0 0 1 1.066 0Zm-.61 1.429.001.001-5.25 1.68a.251.251 0 0 0-.174.237V7c0 1.36.275 2.666 1.057 3.859.784 1.194 2.121 2.342 4.366 3.298a.196.196 0 0 0 .154 0c2.245-.957 3.582-2.103 4.366-3.297C13.225 9.666 13.5 8.358 13.5 7V3.48a.25.25 0 0 0-.174-.238l-5.25-1.68a.25.25 0 0 0-.153 0ZM11.28 6.28l-3.5 3.5a.75.75 0 0 1-1.06 0l-1.5-1.5a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215l.97.97 2.97-2.97a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+</template>
+
+<template id="heart-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-heart">
+    <path d="m8 14.25.345.666a.75.75 0 0 1-.69 0l-.008-.004-.018-.01a7.152 7.152 0 0 1-.31-.17 22.055 22.055 0 0 1-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.066 22.066 0 0 1-3.744 2.584l-.018.01-.006.003h-.002ZM4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.58 20.58 0 0 0 8 13.393a20.58 20.58 0 0 0 3.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.749.749 0 0 1-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5Z"></path>
+</svg>
+</template>
+
+<template id="server-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-server">
+    <path d="M1.75 1h12.5c.966 0 1.75.784 1.75 1.75v4c0 .372-.116.717-.314 1 .198.283.314.628.314 1v4a1.75 1.75 0 0 1-1.75 1.75H1.75A1.75 1.75 0 0 1 0 12.75v-4c0-.358.109-.707.314-1a1.739 1.739 0 0 1-.314-1v-4C0 1.784.784 1 1.75 1ZM1.5 2.75v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25Zm.25 5.75a.25.25 0 0 0-.25.25v4c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-4a.25.25 0 0 0-.25-.25ZM7 4.75A.75.75 0 0 1 7.75 4h4.5a.75.75 0 0 1 0 1.5h-4.5A.75.75 0 0 1 7 4.75ZM7.75 10h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM3 4.75A.75.75 0 0 1 3.75 4h.5a.75.75 0 0 1 0 1.5h-.5A.75.75 0 0 1 3 4.75ZM3.75 10h.5a.75.75 0 0 1 0 1.5h-.5a.75.75 0 0 1 0-1.5Z"></path>
+</svg>
+</template>
+
+<template id="globe-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-globe">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM5.78 8.75a9.64 9.64 0 0 0 1.363 4.177c.255.426.542.832.857 1.215.245-.296.551-.705.857-1.215A9.64 9.64 0 0 0 10.22 8.75Zm4.44-1.5a9.64 9.64 0 0 0-1.363-4.177c-.307-.51-.612-.919-.857-1.215a9.927 9.927 0 0 0-.857 1.215A9.64 9.64 0 0 0 5.78 7.25Zm-5.944 1.5H1.543a6.507 6.507 0 0 0 4.666 5.5c-.123-.181-.24-.365-.352-.552-.715-1.192-1.437-2.874-1.581-4.948Zm-2.733-1.5h2.733c.144-2.074.866-3.756 1.58-4.948.12-.197.237-.381.353-.552a6.507 6.507 0 0 0-4.666 5.5Zm10.181 1.5c-.144 2.074-.866 3.756-1.58 4.948-.12.197-.237.381-.353.552a6.507 6.507 0 0 0 4.666-5.5Zm2.733-1.5a6.507 6.507 0 0 0-4.666-5.5c.123.181.24.365.353.552.714 1.192 1.436 2.874 1.58 4.948Z"></path>
+</svg>
+</template>
+
+<template id="issue-opened-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened">
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
+</svg>
+</template>
+
+<template id="device-mobile-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-mobile">
+    <path d="M3.75 0h8.5C13.216 0 14 .784 14 1.75v12.5A1.75 1.75 0 0 1 12.25 16h-8.5A1.75 1.75 0 0 1 2 14.25V1.75C2 .784 2.784 0 3.75 0ZM3.5 1.75v12.5c0 .138.112.25.25.25h8.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25h-8.5a.25.25 0 0 0-.25.25ZM8 13a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+</svg>
+</template>
+
+<template id="package-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-package">
+    <path d="m8.878.392 5.25 3.045c.54.314.872.89.872 1.514v6.098a1.75 1.75 0 0 1-.872 1.514l-5.25 3.045a1.75 1.75 0 0 1-1.756 0l-5.25-3.045A1.75 1.75 0 0 1 1 11.049V4.951c0-.624.332-1.201.872-1.514L7.122.392a1.75 1.75 0 0 1 1.756 0ZM7.875 1.69l-4.63 2.685L8 7.133l4.755-2.758-4.63-2.685a.248.248 0 0 0-.25 0ZM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432Zm6.25 8.271 4.625-2.683a.25.25 0 0 0 .125-.216V5.677L8.75 8.432Z"></path>
+</svg>
+</template>
+
+<template id="credit-card-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-credit-card">
+    <path d="M10.75 9a.75.75 0 0 0 0 1.5h1.5a.75.75 0 0 0 0-1.5h-1.5Z"></path><path d="M0 3.75C0 2.784.784 2 1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25ZM14.5 6.5h-13v5.75c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25Zm0-2.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25V5h13Z"></path>
+</svg>
+</template>
+
+<template id="play-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+</template>
+
+<template id="gift-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-gift">
+    <path d="M2 2.75A2.75 2.75 0 0 1 4.75 0c.983 0 1.873.42 2.57 1.232.268.318.497.668.68 1.042.183-.375.411-.725.68-1.044C9.376.42 10.266 0 11.25 0a2.75 2.75 0 0 1 2.45 4h.55c.966 0 1.75.784 1.75 1.75v2c0 .698-.409 1.301-1 1.582v4.918A1.75 1.75 0 0 1 13.25 16H2.75A1.75 1.75 0 0 1 1 14.25V9.332C.409 9.05 0 8.448 0 7.75v-2C0 4.784.784 4 1.75 4h.55c-.192-.375-.3-.8-.3-1.25ZM7.25 9.5H2.5v4.75c0 .138.112.25.25.25h4.5Zm1.5 0v5h4.5a.25.25 0 0 0 .25-.25V9.5Zm0-4V8h5.5a.25.25 0 0 0 .25-.25v-2a.25.25 0 0 0-.25-.25Zm-7 0a.25.25 0 0 0-.25.25v2c0 .138.112.25.25.25h5.5V5.5h-5.5Zm3-4a1.25 1.25 0 0 0 0 2.5h2.309c-.233-.818-.542-1.401-.878-1.793-.43-.502-.915-.707-1.431-.707ZM8.941 4h2.309a1.25 1.25 0 0 0 0-2.5c-.516 0-1 .205-1.43.707-.337.392-.646.975-.879 1.793Z"></path>
+</svg>
+</template>
+
+<template id="code-square-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code-square">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25Zm1.75-.25a.25.25 0 0 0-.25.25v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25Zm7.47 3.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L10.69 8 9.22 6.53a.75.75 0 0 1 0-1.06ZM6.78 6.53 5.31 8l1.47 1.47a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+</template>
+
+<template id="device-desktop-icon">
+  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-device-desktop">
+    <path d="M14.25 1c.966 0 1.75.784 1.75 1.75v7.5A1.75 1.75 0 0 1 14.25 12h-3.727c.099 1.041.52 1.872 1.292 2.757A.752.752 0 0 1 11.25 16h-6.5a.75.75 0 0 1-.565-1.243c.772-.885 1.192-1.716 1.292-2.757H1.75A1.75 1.75 0 0 1 0 10.25v-7.5C0 1.784.784 1 1.75 1ZM1.75 2.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25ZM9.018 12H6.982a5.72 5.72 0 0 1-.765 2.5h3.566a5.72 5.72 0 0 1-.765-2.5Z"></path>
+</svg>
+</template>
+
+        <div class="position-relative">
+                <ul
+                  role="listbox"
+                  class="ActionListWrap QueryBuilder-ListWrap"
+                  aria-label="Suggestions"
+                  data-action="
+                    combobox-commit:query-builder#comboboxCommit
+                    mousedown:query-builder#resultsMousedown
+                  "
+                  data-target="query-builder.resultsList"
+                  data-persist-list=false
+                  id="query-builder-test-results"
+                  tabindex="-1"
+                ></ul>
+        </div>
+      <div class="FormControl-inlineValidation" id="validation-8701647c-c135-4587-a201-f1f4ffc180e5" hidden="hidden">
+        <span class="FormControl-inlineValidation--visual">
+          <svg aria-hidden="true" height="12" viewBox="0 0 12 12" version="1.1" width="12" data-view-component="true" class="octicon octicon-alert-fill">
+    <path d="M4.855.708c.5-.896 1.79-.896 2.29 0l4.675 8.351a1.312 1.312 0 0 1-1.146 1.954H1.33A1.313 1.313 0 0 1 .183 9.058ZM7 7V3H5v4Zm-1 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"></path>
+</svg>
+        </span>
+        <span></span>
+</div>    </div>
+    <div data-target="query-builder.screenReaderFeedback" aria-live="polite" aria-atomic="true" class="sr-only"></div>
+</query-builder></form>
+          <div class="d-flex flex-row color-fg-muted px-3 text-small color-bg-default search-feedback-prompt">
+            <a target="_blank" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax" data-view-component="true" class="Link color-fg-accent text-normal ml-2">Search syntax tips</a>            <div class="d-flex flex-1"></div>
+          </div>
+        </div>
+</div>
+
+    </div>
+</modal-dialog></div>
+  </div>
+  <div data-action="click:qbsearch-input#retract" class="dark-backdrop position-fixed" hidden data-target="qbsearch-input.darkBackdrop"></div>
+  <div class="color-fg-default">
+    
+<dialog-helper>
+  <dialog data-target="qbsearch-input.feedbackDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="feedback-dialog" aria-modal="true" aria-labelledby="feedback-dialog-title" aria-describedby="feedback-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade Overlay--disableScroll">
+    <div data-view-component="true" class="Overlay-header">
+  <div class="Overlay-headerContentWrap">
+    <div class="Overlay-titleWrap">
+      <h1 class="Overlay-title " id="feedback-dialog-title">
+        Provide feedback
+      </h1>
+        
+    </div>
+    <div class="Overlay-actionWrap">
+      <button data-close-dialog-id="feedback-dialog" aria-label="Close" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg></button>
+    </div>
+  </div>
+  
+</div>
+      <scrollable-region data-labelled-by="feedback-dialog-title">
+        <div data-view-component="true" class="Overlay-body">        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="code-search-feedback-form" data-turbo="false" action="/search/feedback" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="QI7yfu9Z9ZktowH5blzDEAUUGbiSxtAhj4ak3sB2L5mRjcShRO/yllGiKCE2bjuaQWXA3pAoUNO7u4Qk2Gfz4Q==" />
+          <p>We read every piece of feedback, and take your input very seriously.</p>
+          <textarea name="feedback" class="form-control width-full mb-2" style="height: 120px" id="feedback"></textarea>
+          <input name="include_email" id="include_email" aria-label="Include my email address so I can be contacted" class="form-control mr-2" type="checkbox">
+          <label for="include_email" style="font-weight: normal">Include my email address so I can be contacted</label>
+</form></div>
+      </scrollable-region>
+      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd">          <button data-close-dialog-id="feedback-dialog" type="button" data-view-component="true" class="btn">    Cancel
+</button>
+          <button form="code-search-feedback-form" data-action="click:qbsearch-input#submitFeedback" type="submit" data-view-component="true" class="btn-primary btn">    Submit feedback
+</button>
+</div>
+</dialog></dialog-helper>
+
+    <custom-scopes data-target="qbsearch-input.customScopesManager">
+    
+<dialog-helper>
+  <dialog data-target="custom-scopes.customScopesModalDialog" data-action="close:qbsearch-input#handleDialogClose cancel:qbsearch-input#handleDialogClose" id="custom-scopes-dialog" aria-modal="true" aria-labelledby="custom-scopes-dialog-title" aria-describedby="custom-scopes-dialog-description" data-view-component="true" class="Overlay Overlay-whenNarrow Overlay--size-medium Overlay--motion-scaleFade Overlay--disableScroll">
+    <div data-view-component="true" class="Overlay-header Overlay-header--divided">
+  <div class="Overlay-headerContentWrap">
+    <div class="Overlay-titleWrap">
+      <h1 class="Overlay-title " id="custom-scopes-dialog-title">
+        Saved searches
+      </h1>
+        <h2 id="custom-scopes-dialog-description" class="Overlay-description">Use saved searches to filter your results more quickly</h2>
+    </div>
+    <div class="Overlay-actionWrap">
+      <button data-close-dialog-id="custom-scopes-dialog" aria-label="Close" aria-label="Close" type="button" data-view-component="true" class="close-button Overlay-closeButton"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg></button>
+    </div>
+  </div>
+  
+</div>
+      <scrollable-region data-labelled-by="custom-scopes-dialog-title">
+        <div data-view-component="true" class="Overlay-body">        <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
+
+        <div hidden class="create-custom-scope-form" data-target="custom-scopes.createCustomScopeForm">
+        <!-- '"` --><!-- </textarea></xmp> --></option></form><form id="custom-scopes-dialog-form" data-turbo="false" action="/search/custom_scopes" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="LEcOQVrUypSkyHu/mK0Hl3mgU376Zle5U50Dy7WXmQ2OYe6ntNQBVjeobH3GEkspl0iCelURhsmslAZyO2wCTw==" />
+          <div data-target="custom-scopes.customScopesModalDialogFlash"></div>
+
+          <input type="hidden" id="custom_scope_id" name="custom_scope_id" data-target="custom-scopes.customScopesIdField">
+
+          <div class="form-group">
+            <label for="custom_scope_name">Name</label>
+            <auto-check src="/search/custom_scopes/check_name" required>
+              <input
+                type="text"
+                name="custom_scope_name"
+                id="custom_scope_name"
+                data-target="custom-scopes.customScopesNameField"
+                class="form-control"
+                autocomplete="off"
+                placeholder="github-ruby"
+                required
+                maxlength="50">
+              <input type="hidden" data-csrf="true" value="mbGTQPjBat9uBONr2iZr9+EB5SATncpwVE+4yiVgtjoB6VNxBRGs+t4rzeRrZNBz3xL+cNT7OzbNsqCUPoZ7TA==" />
+            </auto-check>
+          </div>
+
+          <div class="form-group">
+            <label for="custom_scope_query">Query</label>
+            <input
+              type="text"
+              name="custom_scope_query"
+              id="custom_scope_query"
+              data-target="custom-scopes.customScopesQueryField"
+              class="form-control"
+              autocomplete="off"
+              placeholder="(repo:mona/a OR repo:mona/b) AND lang:python"
+              required
+              maxlength="500">
+          </div>
+
+          <p class="text-small color-fg-muted">
+            To see all available qualifiers, see our <a class="Link--inTextBlock" href="https://docs.github.com/search-github/github-code-search/understanding-github-code-search-syntax">documentation</a>.
+          </p>
+</form>        </div>
+
+        <div data-target="custom-scopes.manageCustomScopesForm">
+          <div data-target="custom-scopes.list"></div>
+        </div>
+
+</div>
+      </scrollable-region>
+      <div data-view-component="true" class="Overlay-footer Overlay-footer--alignEnd Overlay-footer--divided">          <button data-action="click:custom-scopes#customScopesCancel" type="button" data-view-component="true" class="btn">    Cancel
+</button>
+          <button form="custom-scopes-dialog-form" data-action="click:custom-scopes#customScopesSubmit" data-target="custom-scopes.customScopesSubmitButton" type="submit" data-view-component="true" class="btn-primary btn">    Create saved search
+</button>
+</div>
+</dialog></dialog-helper>
+    </custom-scopes>
+  </div>
+</qbsearch-input>
+
+
+            <div class="position-relative HeaderMenu-link-wrap d-lg-inline-block">
+              <a
+                href="/login?return_to=https%3A%2F%2Fgithub.com%2Fkiooeht%2FModTheSpire%2Fwiki%2FStS-Lib"
+                class="HeaderMenu-link HeaderMenu-link--sign-in HeaderMenu-button flex-shrink-0 no-underline d-none d-lg-inline-flex border border-lg-0 rounded px-2 py-1"
+                style="margin-left: 12px;"
+                data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="bf9436b8e2e72d86f5bc0cbb673bd7cfd1d5965e463ba7714d028ed64a7820e5"
+                data-analytics-event="{&quot;category&quot;:&quot;Marketing nav&quot;,&quot;action&quot;:&quot;click to go to homepage&quot;,&quot;label&quot;:&quot;ref_page:Marketing;ref_cta:Sign in;ref_loc:Header&quot;}"
+              >
+                Sign in
+              </a>
+            </div>
+
+              <a href="/signup?ref_cta=Sign+up&amp;ref_loc=header+logged+out&amp;ref_page=%2F%3Cuser-name%3E%2F%3Crepo-name%3E%2Fwiki%2Fshow&amp;source=header-repo&amp;source_repo=kiooeht%2FModTheSpire"
+                class="HeaderMenu-link HeaderMenu-link--sign-up HeaderMenu-button flex-shrink-0 d-flex d-lg-inline-flex no-underline border color-border-default rounded px-2 py-1"
+                data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;site header menu&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;SIGN_UP&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="bf9436b8e2e72d86f5bc0cbb673bd7cfd1d5965e463ba7714d028ed64a7820e5"
+                data-analytics-event="{&quot;category&quot;:&quot;Sign up&quot;,&quot;action&quot;:&quot;click to sign up for account&quot;,&quot;label&quot;:&quot;ref_page:/&lt;user-name&gt;/&lt;repo-name&gt;/wiki/show;ref_cta:Sign up;ref_loc:header logged out&quot;}"
+              >
+                Sign up
+              </a>
+
+                <div class="AppHeader-appearanceSettings">
+    <react-partial-anchor>
+      <button data-target="react-partial-anchor.anchor" id="icon-button-7910e4f6-f432-40b0-8446-145394441448" aria-labelledby="tooltip-1dce0bed-139e-4490-b916-4d52ecdf502b" type="button" disabled="disabled" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium AppHeader-button HeaderMenu-link border cursor-wait">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-sliders Button-visual">
+    <path d="M15 2.75a.75.75 0 0 1-.75.75h-4a.75.75 0 0 1 0-1.5h4a.75.75 0 0 1 .75.75Zm-8.5.75v1.25a.75.75 0 0 0 1.5 0v-4a.75.75 0 0 0-1.5 0V2H1.75a.75.75 0 0 0 0 1.5H6.5Zm1.25 5.25a.75.75 0 0 0 0-1.5h-6a.75.75 0 0 0 0 1.5h6ZM15 8a.75.75 0 0 1-.75.75H11.5V10a.75.75 0 1 1-1.5 0V6a.75.75 0 0 1 1.5 0v1.25h2.75A.75.75 0 0 1 15 8Zm-9 5.25v-2a.75.75 0 0 0-1.5 0v1.25H1.75a.75.75 0 0 0 0 1.5H4.5v1.25a.75.75 0 0 0 1.5 0v-2Zm9 0a.75.75 0 0 1-.75.75h-6a.75.75 0 0 1 0-1.5h6a.75.75 0 0 1 .75.75Z"></path>
+</svg>
+</button><tool-tip id="tooltip-1dce0bed-139e-4490-b916-4d52ecdf502b" for="icon-button-7910e4f6-f432-40b0-8446-145394441448" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Appearance settings</tool-tip>
+
+      <template data-target="react-partial-anchor.template">
+        <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/primer-react.ad9424369aeb6fec9e91.module.css" />
+<link crossorigin="anonymous" media="all" rel="stylesheet" href="https://github.githubassets.com/assets/appearance-settings.6c63a6de228d6520804d.module.css" />
+
+<react-partial
+  partial-name="appearance-settings"
+  data-ssr="false"
+  data-attempted-ssr="false"
+  data-react-profiling="false"
+>
+  
+  <script type="application/json" data-target="react-partial.embeddedData">{"props":{}}</script>
+  <div data-target="react-partial.reactRoot"></div>
+</react-partial>
+
+
+      </template>
+    </react-partial-anchor>
+  </div>
+
+          <button type="button" class="sr-only js-header-menu-focus-trap d-block d-lg-none">Resetting focus</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+
+      <div hidden="hidden" data-view-component="true" class="js-stale-session-flash stale-session-flash flash flash-warn flash-full">
+  
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        <span class="js-stale-session-flash-signed-in" hidden>You signed in with another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+        <span class="js-stale-session-flash-signed-out" hidden>You signed out in another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+        <span class="js-stale-session-flash-switched" hidden>You switched accounts on another tab or window. <a class="Link--inTextBlock" href="">Reload</a> to refresh your session.</span>
+
+    <button id="icon-button-b964bbf0-a09d-4024-a8d9-e17e6cf967c1" aria-labelledby="tooltip-550dfa67-8421-41e9-afae-2f15dafc757a" type="button" data-view-component="true" class="Button Button--iconOnly Button--invisible Button--medium flash-close js-flash-close">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x Button-visual">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+</button><tool-tip id="tooltip-550dfa67-8421-41e9-afae-2f15dafc757a" for="icon-button-b964bbf0-a09d-4024-a8d9-e17e6cf967c1" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Dismiss alert</tool-tip>
+
+
+  
+</div>
+    </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+
+
+
+
+
+
+
+    <div id="js-flash-container" class="flash-container" data-turbo-replace>
+
+
+
+
+  <template class="js-flash-template">
+    
+<div class="flash flash-full   {{ className }}">
+  <div >
+    <button autofocus class="flash-close js-flash-close" type="button" aria-label="Dismiss this message">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+    </button>
+    <div aria-atomic="true" role="alert" class="js-flash-alert">
+      
+      <div>{{ message }}</div>
+
+    </div>
+  </div>
+</div>
+  </template>
+</div>
+
+
+    
+
+
+
+
+
+
+  <div
+    class="application-main "
+    data-commit-hovercards-enabled
+    data-discussion-hovercards-enabled
+    data-issue-and-pr-hovercards-enabled
+    data-project-hovercards-enabled
+  >
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
+    <main id="js-repo-pjax-container" >
+      
+  
+    
+
+
+
+
+
+
+  
+  <div id="repository-container-header"  class="pt-3 hide-full-screen" style="background-color: var(--page-header-bgColor, var(--color-page-header-bg));" data-turbo-replace>
+
+      <div class="d-flex flex-nowrap flex-justify-end mb-3  px-3 px-lg-5" style="gap: 1rem;">
+
+        <div class="flex-auto min-width-0 width-fit">
+            
+  <div class=" d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo color-fg-muted mr-2">
+    <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z"></path>
+</svg>
+    
+    <span class="author flex-self-stretch" itemprop="author">
+      <a class="url fn" rel="author" data-hovercard-type="user" data-hovercard-url="/users/kiooeht/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/kiooeht">
+        kiooeht
+</a>    </span>
+    <span class="mx-1 flex-self-stretch color-fg-muted">/</span>
+    <strong itemprop="name" class="mr-2 flex-self-stretch">
+      <a data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" href="/kiooeht/ModTheSpire">ModTheSpire</a>
+    </strong>
+
+    <span></span><span class="Label Label--secondary v-align-middle mr-1">Public</span>
+  </div>
+
+
+        </div>
+
+        <div id="repository-details-container" class="flex-shrink-0" data-turbo-replace style="max-width: 70%;">
+            <ul class="pagehead-actions flex-shrink-0 d-none d-md-inline" style="padding: 2px 0;">
+    
+      
+
+  <li>
+            <a href="/login?return_to=%2Fkiooeht%2FModTheSpire" rel="nofollow" id="repository-details-watch-button" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;notification subscription menu watch&quot;,&quot;repository_id&quot;:null,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="f0c666d93abd1eb53291538aa9fd0d390b93e2903b8f121ccde1a9adedbdd03b" aria-label="You must be signed in to change notification settings" data-view-component="true" class="btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-bell mr-2">
+    <path d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"></path>
+</svg>Notifications
+</a>    <tool-tip id="tooltip-fcea60de-2180-4871-a896-6e9111b03ad2" for="repository-details-watch-button" popover="manual" data-direction="s" data-type="description" data-view-component="true" class="sr-only position-absolute">You must be signed in to change notification settings</tool-tip>
+
+  </li>
+
+  <li>
+          <a icon="repo-forked" id="fork-button" href="/login?return_to=%2Fkiooeht%2FModTheSpire" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;repo details fork button&quot;,&quot;repository_id&quot;:118042024,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="48d028ccf059edd5269b06b9e5bf7dc00cde90c6984c43c82ea56d08730d9f1f" data-view-component="true" class="btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-repo-forked mr-2">
+    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"></path>
+</svg>Fork
+    <span id="repo-network-counter" data-pjax-replace="true" data-turbo-replace="true" title="92" data-view-component="true" class="Counter">92</span>
+</a>
+  </li>
+
+  <li>
+        <div data-view-component="true" class="BtnGroup d-flex">
+        <a href="/login?return_to=%2Fkiooeht%2FModTheSpire" rel="nofollow" data-hydro-click="{&quot;event_type&quot;:&quot;authentication.click&quot;,&quot;payload&quot;:{&quot;location_in_page&quot;:&quot;star button&quot;,&quot;repository_id&quot;:118042024,&quot;auth_type&quot;:&quot;LOG_IN&quot;,&quot;originating_url&quot;:&quot;https://github.com/kiooeht/ModTheSpire/wiki/StS-Lib&quot;,&quot;user_id&quot;:null}}" data-hydro-click-hmac="995df44c35becb10b402f2e44b3f09285d32a3e63108c4fc9b1ef1666996fbd2" aria-label="You must be signed in to star a repository" data-view-component="true" class="tooltipped tooltipped-sw btn-sm btn">    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-star v-align-text-bottom d-inline-block mr-2">
+    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z"></path>
+</svg><span data-view-component="true" class="d-inline">
+          Star
+</span>          <span id="repo-stars-counter-star" aria-label="460 users starred this repository" data-singular-suffix="user starred this repository" data-plural-suffix="users starred this repository" data-turbo-replace="true" title="460" data-view-component="true" class="Counter js-social-count">460</span>
+</a></div>
+  </li>
+
+</ul>
+
+        </div>
+      </div>
+
+        <div id="responsive-meta-container" data-turbo-replace>
+</div>
+
+
+          <nav data-pjax="#js-repo-pjax-container" aria-label="Repository" data-view-component="true" class="js-repo-nav js-sidenav-container-pjax js-responsive-underlinenav overflow-hidden UnderlineNav px-3 px-md-4 px-lg-5">
+
+  <ul data-view-component="true" class="UnderlineNav-body list-style-none">
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="code-tab" href="/kiooeht/ModTheSpire" data-tab-item="i0code-tab" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages repo_deployments repo_attestations /kiooeht/ModTheSpire" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g c" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Code&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code UnderlineNav-octicon d-none d-sm-inline">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+        <span data-content="Code">Code</span>
+          <span id="code-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="issues-tab" href="/kiooeht/ModTheSpire/issues" data-tab-item="i1issues-tab" data-selected-links="repo_issues repo_labels repo_milestones /kiooeht/ModTheSpire/issues" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g i" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Issues&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
+</svg>
+        <span data-content="Issues">Issues</span>
+          <span id="issues-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="64" data-view-component="true" class="Counter">64</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="pull-requests-tab" href="/kiooeht/ModTheSpire/pulls" data-tab-item="i2pull-requests-tab" data-selected-links="repo_pulls checks /kiooeht/ModTheSpire/pulls" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g p" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Pull requests&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
+</svg>
+        <span data-content="Pull requests">Pull requests</span>
+          <span id="pull-requests-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="11" data-view-component="true" class="Counter">11</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="actions-tab" href="/kiooeht/ModTheSpire/actions" data-tab-item="i3actions-tab" data-selected-links="repo_actions /kiooeht/ModTheSpire/actions" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g a" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Actions&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+        <span data-content="Actions">Actions</span>
+          <span id="actions-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="projects-tab" href="/kiooeht/ModTheSpire/projects" data-tab-item="i4projects-tab" data-selected-links="repo_projects new_repo_project repo_project /kiooeht/ModTheSpire/projects" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g b" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Projects&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-table UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25ZM6.5 6.5v8h7.75a.25.25 0 0 0 .25-.25V6.5Zm8-1.5V1.75a.25.25 0 0 0-.25-.25H6.5V5Zm-13 1.5v7.75c0 .138.112.25.25.25H5v-8ZM5 5V1.5H1.75a.25.25 0 0 0-.25.25V5Z"></path>
+</svg>
+        <span data-content="Projects">Projects</span>
+          <span id="projects-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="0" hidden="hidden" data-view-component="true" class="Counter">0</span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="wiki-tab" href="/kiooeht/ModTheSpire/wiki" data-tab-item="i5wiki-tab" data-selected-links="repo_wiki /kiooeht/ModTheSpire/wiki" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g w" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Wiki&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" aria-current="page" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item selected">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+        <span data-content="Wiki">Wiki</span>
+          <span id="wiki-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="security-tab" href="/kiooeht/ModTheSpire/security" data-tab-item="i6security-tab" data-selected-links="security overview alerts policy token_scanning code_scanning /kiooeht/ModTheSpire/security" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-hotkey="g s" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Security&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        <span data-content="Security">Security</span>
+          <include-fragment src="/kiooeht/ModTheSpire/security/overall-count" accept="text/fragment+html" data-nonce="v2:e99ac516-3c43-0c63-3af0-706d3a96d1a7" data-view-component="true">
+  
+  <div data-show-on-forbidden-error hidden>
+    <div class="Box">
+  <div class="blankslate-container">
+    <div data-view-component="true" class="blankslate blankslate-spacious color-bg-default rounded-2">
+      
+
+      <h3 data-view-component="true" class="blankslate-heading">        Uh oh!
+</h3>
+      <p data-view-component="true">        <p class="color-fg-muted my-2 mb-2 ws-normal">There was an error while loading. <a class="Link--inTextBlock" data-turbo="false" href="" aria-label="Please reload this page">Please reload this page</a>.</p>
+</p>
+
+</div>  </div>
+</div>  </div>
+</include-fragment>
+
+    
+</a></li>
+      <li data-view-component="true" class="d-inline-flex">
+  <a id="insights-tab" href="/kiooeht/ModTheSpire/pulse" data-tab-item="i7insights-tab" data-selected-links="repo_graphs repo_contributors dependency_graph dependabot_updates pulse people community /kiooeht/ModTheSpire/pulse" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" data-analytics-event="{&quot;category&quot;:&quot;Underline navbar&quot;,&quot;action&quot;:&quot;Click tab&quot;,&quot;label&quot;:&quot;Insights&quot;,&quot;target&quot;:&quot;UNDERLINE_NAV.TAB&quot;}" data-view-component="true" class="UnderlineNav-item no-wrap js-responsive-underlinenav-item js-selected-navigation-item">
+    
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph UnderlineNav-octicon d-none d-sm-inline">
+    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+        <span data-content="Insights">Insights</span>
+          <span id="insights-repo-tab-count" data-pjax-replace="" data-turbo-replace="" title="Not available" data-view-component="true" class="Counter"></span>
+
+
+    
+</a></li>
+</ul>
+    <div style="visibility:hidden;" data-view-component="true" class="UnderlineNav-actions js-responsive-underlinenav-overflow position-absolute pr-3 pr-md-4 pr-lg-5 right-0">      <action-menu data-select-variant="none" data-view-component="true">
+  <focus-group direction="vertical" mnemonics retain>
+    <button id="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-button" popovertarget="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-overlay" aria-controls="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-list" aria-haspopup="true" aria-labelledby="tooltip-4eef737d-51b3-4880-ad92-dd5dc72aa17b" type="button" data-view-component="true" class="Button Button--iconOnly Button--secondary Button--medium UnderlineNav-item">  <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-kebab-horizontal Button-visual">
+    <path d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path>
+</svg>
+</button><tool-tip id="tooltip-4eef737d-51b3-4880-ad92-dd5dc72aa17b" for="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-button" popover="manual" data-direction="s" data-type="label" data-view-component="true" class="sr-only position-absolute">Additional navigation options</tool-tip>
+
+
+<anchored-position data-target="action-menu.overlay" id="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-overlay" anchor="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-button" align="start" side="outside-bottom" anchor-offset="normal" popover="auto" data-view-component="true">
+  <div data-view-component="true" class="Overlay Overlay--size-auto">
+    
+      <div data-view-component="true" class="Overlay-body Overlay-body--paddingNone">          <action-list>
+  <div data-view-component="true">
+    <ul aria-labelledby="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-button" id="action-menu-0d4be584-c0f6-4fa6-a487-62e0934a3908-list" role="menu" data-view-component="true" class="ActionListWrap--inset ActionListWrap">
+        <li hidden="hidden" data-menu-item="i0code-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-30fdcd2d-65c0-4a99-9dbc-4f5a4c37c255" href="/kiooeht/ModTheSpire" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Code
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i1issues-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-78be29b3-a17c-4dfa-b6c8-3b73e8a8c28c" href="/kiooeht/ModTheSpire/issues" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-issue-opened">
+    <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"></path><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Issues
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i2pull-requests-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-f196c11b-9ac0-4eed-9f72-adc79119b264" href="/kiooeht/ModTheSpire/pulls" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-pull-request">
+    <path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354ZM3.75 2.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm0 9.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25.75a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Pull requests
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i3actions-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-c54d9f80-c970-4147-bff8-29619316f7f9" href="/kiooeht/ModTheSpire/actions" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-play">
+    <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Actions
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i4projects-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-51baf909-00d1-429d-849b-cf4318150484" href="/kiooeht/ModTheSpire/projects" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-table">
+    <path d="M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25ZM6.5 6.5v8h7.75a.25.25 0 0 0 .25-.25V6.5Zm8-1.5V1.75a.25.25 0 0 0-.25-.25H6.5V5Zm-13 1.5v7.75c0 .138.112.25.25.25H5v-8ZM5 5V1.5H1.75a.25.25 0 0 0-.25.25V5Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Projects
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i5wiki-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-1f259274-7ed6-4223-9323-420875be58d3" href="/kiooeht/ModTheSpire/wiki" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-book">
+    <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Wiki
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i6security-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-d4fba720-1e10-448f-9ffb-49c1336e9b9a" href="/kiooeht/ModTheSpire/security" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-shield">
+    <path d="M7.467.133a1.748 1.748 0 0 1 1.066 0l5.25 1.68A1.75 1.75 0 0 1 15 3.48V7c0 1.566-.32 3.182-1.303 4.682-.983 1.498-2.585 2.813-5.032 3.855a1.697 1.697 0 0 1-1.33 0c-2.447-1.042-4.049-2.357-5.032-3.855C1.32 10.182 1 8.566 1 7V3.48a1.75 1.75 0 0 1 1.217-1.667Zm.61 1.429a.25.25 0 0 0-.153 0l-5.25 1.68a.25.25 0 0 0-.174.238V7c0 1.358.275 2.666 1.057 3.86.784 1.194 2.121 2.34 4.366 3.297a.196.196 0 0 0 .154 0c2.245-.956 3.582-2.104 4.366-3.298C13.225 9.666 13.5 8.36 13.5 7V3.48a.251.251 0 0 0-.174-.237l-5.25-1.68ZM8.75 4.75v3a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 1.5 0ZM9 10.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Security
+</span>      
+</a>
+  
+</li>
+        <li hidden="hidden" data-menu-item="i7insights-tab" data-targets="action-list.items" role="none" data-view-component="true" class="ActionListItem">
+    
+    
+    <a tabindex="-1" id="item-7ec60411-f2da-4dc5-b622-95d78fd22a8a" href="/kiooeht/ModTheSpire/pulse" role="menuitem" data-view-component="true" class="ActionListContent ActionListContent--visual16">
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-graph">
+    <path d="M1.5 1.75V13.5h13.75a.75.75 0 0 1 0 1.5H.75a.75.75 0 0 1-.75-.75V1.75a.75.75 0 0 1 1.5 0Zm14.28 2.53-5.25 5.25a.75.75 0 0 1-1.06 0L7 7.06 4.28 9.78a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042l3.25-3.25a.75.75 0 0 1 1.06 0L10 7.94l4.72-4.72a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path>
+</svg>
+        </span>
+      
+        <span data-view-component="true" class="ActionListItem-label">
+          Insights
+</span>      
+</a>
+  
+</li>
+</ul>    
+</div></action-list>
+
+
+</div>
+      
+</div></anchored-position>  </focus-group>
+</action-menu></div>
+</nav>
+
+  </div>
+
+  
+
+
+
+<turbo-frame id="repo-content-turbo-frame" target="_top" data-turbo-action="advance" class="">
+    <div id="repo-content-pjax-container" class="repository-content " >
+    
+
+
+
+    
+      
+  <div class="clearfix container-xl px-3 px-md-4 px-lg-5 mt-4 outer" id="wiki-wrapper">
+    <div class="gh-header">
+      <h1 class="gh-header-title mr-0">Create new page</h1>
+    </div>
+
+    <div id="wiki-content" class="create">
+      <div id="gollum-editor" class="pt-2 mt-2 mb-6 create gollum-editor">
+        <!-- '"` --><!-- </textarea></xmp> --></option></form><form name="gollum-editor" data-warn-unsaved-changes="Your changes will be lost." data-turbo="false" action="/kiooeht/ModTheSpire/wiki" accept-charset="UTF-8" method="post"><input type="hidden" data-csrf="true" name="authenticity_token" value="b4UTlJ7ai4QjfDSql7FjfZYMWlG6nCYznuVYVdE8rfI/2mk547pLARqe3g9G5yrUNeRc6Qi4OQeK7clbXUxzKQ==" />            <div id="gollum-editor-title-field" class="position-relative mb-3">
+    <text-expander keys=":" data-emoji-url="/autocomplete/emoji">
+      <input type="text" name="wiki[name]" id="gollum-editor-page-title" value="StS Lib" class="form-control text-bold input-block js-quick-submit" placeholder="Title" aria-label="Title" required="required" />
+    </text-expander>
+  </div>
+
+
+<div class="js-previewable-comment-form previewable-comment-form write-selected" data-preview-url="/kiooeht/ModTheSpire/wiki/_preview">
+  <input type="hidden" data-csrf="true" class="js-data-preview-url-csrf" value="qZi4SIlh4Hu0DAAuyU32vUVeWM4KPfSE3O6xLIp/ikGwoeFr/BFU005XD/WKa6EXZWIiOzn8eyrTA7m4zphBjw==" />
+  <div class="comment-form-head tabnav color-bg-default p-0 border-left-0 border-top-0 border-right-0">
+    <div class="tabnav-tabs">
+      <button scheme="link" type="button" data-view-component="true" class="tabnav-tab write-tab js-write-tab selected">Write</button>
+      <button scheme="link" type="button" data-view-component="true" class="tabnav-tab preview-tab js-preview-tab">Preview</button>
+    </div>
+  </div>
+
+  <div id="gollum-editor-function-bar" class="my-2 pb-2 border-bottom clearfix">
+    <div id="gollum-editor-function-buttons" class="float-md-left d-none overflow-auto no-wrap gollum-editor-function-buttons">
+
+  <div class="BtnGroup">
+    <button type="button" id="function-h1" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert h1">
+      <b>h1</b>
+    </button>
+    <button type="button" id="function-h2" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert h2">
+      <b>h2</b>
+    </button>
+    <button type="button" id="function-h3" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert h3">
+      <b>h3</b>
+    </button>
+  </div>
+
+  <div class="BtnGroup">
+    <button type="button" id="function-link" class="btn btn-sm BtnGroup-item function-button" aria-label="Add link">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-link">
+    <path d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"></path>
+</svg>
+    </button>
+    <button type="button" id="function-image" class="btn btn-sm BtnGroup-item function-button" aria-label="Add image">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-image">
+    <path d="M16 13.25A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75ZM1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h.94l.03-.03 6.077-6.078a1.75 1.75 0 0 1 2.412-.06L14.5 10.31V2.75a.25.25 0 0 0-.25-.25Zm12.5 11a.25.25 0 0 0 .25-.25v-.917l-4.298-3.889a.25.25 0 0 0-.344.009L4.81 13.5ZM7 6a2 2 0 1 1-3.999.001A2 2 0 0 1 7 6ZM5.5 6a.5.5 0 1 0-1 0 .5.5 0 0 0 1 0Z"></path>
+</svg>
+    </button>
+  </div>
+
+  <div class="BtnGroup">
+    <button type="button" id="function-bold" class="btn btn-sm BtnGroup-item function-button" aria-label="Add bold text">
+      <b>B</b>
+    </button>
+    <button type="button" id="function-italic" class="btn btn-sm BtnGroup-item function-button" aria-label="Add italic text">
+      <em>i</em>
+    </button>
+    <button type="button" id="function-code" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert code">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-code">
+    <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+    </button>
+  </div>
+
+  <div class="BtnGroup">
+    <button type="button" id="function-ul" class="btn btn-sm BtnGroup-item function-button" aria-label="Add unordered list">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-list-unordered">
+    <path d="M5.75 2.5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2 14a1 1 0 1 1 0-2 1 1 0 0 1 0 2Zm1-6a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM2 4a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"></path>
+</svg>
+    </button>
+    <button type="button" id="function-ol" class="btn btn-sm BtnGroup-item function-button" aria-label="Add ordered list">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-list-ordered">
+    <path d="M5 3.25a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 3.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5A.75.75 0 0 1 5 8.25Zm0 5a.75.75 0 0 1 .75-.75h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1-.75-.75ZM.924 10.32a.5.5 0 0 1-.851-.525l.001-.001.001-.002.002-.004.007-.011c.097-.144.215-.273.348-.384.228-.19.588-.392 1.068-.392.468 0 .858.181 1.126.484.259.294.377.673.377 1.038 0 .987-.686 1.495-1.156 1.845l-.047.035c-.303.225-.522.4-.654.597h1.357a.5.5 0 0 1 0 1H.5a.5.5 0 0 1-.5-.5c0-1.005.692-1.52 1.167-1.875l.035-.025c.531-.396.8-.625.8-1.078a.57.57 0 0 0-.128-.376C1.806 10.068 1.695 10 1.5 10a.658.658 0 0 0-.429.163.835.835 0 0 0-.144.153ZM2.003 2.5V6h.503a.5.5 0 0 1 0 1H.5a.5.5 0 0 1 0-1h.503V3.308l-.28.14a.5.5 0 0 1-.446-.895l1.003-.5a.5.5 0 0 1 .723.447Z"></path>
+</svg>
+    </button>
+    <button type="button" id="function-blockquote" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert blockquote">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-quote">
+    <path d="M1.75 2.5h10.5a.75.75 0 0 1 0 1.5H1.75a.75.75 0 0 1 0-1.5Zm4 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5Zm0 5h8.5a.75.75 0 0 1 0 1.5h-8.5a.75.75 0 0 1 0-1.5ZM2.5 7.75v6a.75.75 0 0 1-1.5 0v-6a.75.75 0 0 1 1.5 0Z"></path>
+</svg>
+    </button>
+    <button type="button" id="function-hr" class="btn btn-sm BtnGroup-item function-button" aria-label="Insert horizontal rule">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-horizontal-rule">
+    <path d="M0 7.75A.75.75 0 0 1 .75 7h14.5a.75.75 0 0 1 0 1.5H.75A.75.75 0 0 1 0 7.75Z"></path>
+</svg>
+    </button>
+  </div>
+
+  <button type="button" id="function-help" class="btn btn-sm hide-sm function-button" aria-label="Help">
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-question">
+    <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.92 6.085h.001a.749.749 0 1 1-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 0 1 1.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.47.513-.692.662-.109.072-.22.138-.313.195l-.006.004a6.24 6.24 0 0 0-.26.16.952.952 0 0 0-.276.245.75.75 0 0 1-1.248-.832c.184-.264.42-.489.692-.661.103-.067.207-.132.313-.195l.007-.004c.1-.061.182-.11.258-.161a.969.969 0 0 0 .277-.245C8.96 6.514 9 6.427 9 6.25a.612.612 0 0 0-.262-.525A1.27 1.27 0 0 0 8 5.5c-.369 0-.595.09-.74.187a1.01 1.01 0 0 0-.34.398ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+  </button>
+</div>
+
+
+      <div id="gollum-editor-format-selector" class="d-flex d-md-block flex-items-center float-md-left mt-2 mt-md-0 ml-md-4 f6">
+        <label class="pr-2 text-bold color-fg-muted" for="wiki_format">Edit mode:</label>
+        <select name="wiki[format]" id="wiki_format" class="form-select form-select select-sm flex-auto"><option value="asciidoc">AsciiDoc</option>
+<option value="creole">Creole</option>
+<option value="markdown">Markdown</option>
+<option value="mediawiki">MediaWiki</option>
+<option value="org">Org-mode</option>
+<option value="pod">Pod</option>
+<option value="rdoc">RDoc</option>
+<option value="textile">Textile</option>
+<option value="rest">reStructuredText</option></select>
+      </div>
+  </div>
+
+  <div id="gollum-editor-help" class="border rounded-2 overflow-hidden jaws" style="display: none">
+  <nav id="gollum-editor-help-parent"
+      class="menu mb-0 f6 rounded-0 float-left border-top-0 border-bottom-0 border-left-0 overflow-auto"
+      style="width: 160px; height: 220px;"
+      aria-label="Element type help navigation bar">
+  </nav>
+  <nav id="gollum-editor-help-list"
+      class="menu mb-0 f6 rounded-0 float-left border-top-0 border-bottom-0 border-left-0 overflow-auto"
+      style="width: 160px; height: 220px;"
+      aria-label="Element type options help navigation bar">
+  </nav>
+  <div id="gollum-editor-help-wrapper" class="p-2 overflow-auto" style="height: 170px">
+    <div id="gollum-editor-help-content" class="ml-1 mr-2 f6"></div>
+  </div>
+</div>
+
+
+  <file-attachment class="js-upload-markdown-image is-default" input="wiki-fileupload" data-upload-repository-id="118042024" data-upload-policy-url="/upload/policies/assets"><input type="hidden" data-csrf="true" class="js-data-upload-policy-url-csrf" value="UqvHKxphSOWs9JWkgiiG4LU9zZJfEUyGqatVguGCZiHAupBQb2YKxjUDx5E3iRxo2ocJaVZ4LIsIlKSZt5p01g==" />
+    <div class="m-0 write-content js-write-bucket upload-enabled">
+      <div id="gollum-error-message" class="flash flash-error d-none">Someone has edited the wiki since you started. Please reload this page and re-apply your changes.</div>
+
+      <text-expander keys=":" data-emoji-url="/autocomplete/emoji">
+        <textarea name="wiki[body]" id="gollum-editor-body" format="markdown" class="form-control mt-2  text-mono input-block gollum-editor-body comment-form-textarea js-comment-field js-quick-submit input-with-fullscreen-icon" aria-label="Page content" required="required">
+</textarea>
+      </text-expander>
+
+        
+  <label class="text-normal drag-and-drop hx_drag-and-drop position-relative d-flex flex-justify-between color-border-emphasis">
+    <input accept=".gif,.jpeg,.jpg,.mov,.mp4,.png,.svg,.webm,.webp" type="file"
+      multiple
+      class="manual-file-chooser manual-file-chooser-transparent top-0 right-0 bottom-0 left-0 width-full ml-0 form-control rounded-top-0"
+        id="wiki-fileupload"
+      >
+    <span class="color-bg-subtle position-absolute top-0 left-0 rounded-bottom-2 width-full height-full" style="pointer-events: none;"></span>
+    <span class="position-relative pr-2" style="pointer-events: none;">
+      <span class="default">
+        Attach files by dragging &amp; dropping, selecting or pasting them.
+      </span>
+      <span class="loading">
+        <span data-view-component="true">
+  <svg style="box-sizing: content-box; color: var(--color-icon-primary);" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" data-view-component="true" class="v-align-text-bottom mr-1 anim-rotate">
+    <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" fill="none" />
+    <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+</svg>    <span class="sr-only">Loading</span>
+</span>
+          <span class="js-file-upload-loading-text" data-file-upload-message="Uploading your files…">
+            Uploading your files…
+          </span>
+      </span>
+      <span class="error bad-file">
+        We don’t support that file type.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again</span> with a
+          GIF, JPEG, JPG, MOV, MP4, PNG, SVG, WEBM or WEBP.
+        </span>
+      </span>
+      <span class="error bad-permissions">
+        Attaching documents requires write permission to this repository.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again</span> with a GIF, JPEG, JPG, MOV, MP4, PNG, SVG, WEBM or WEBP.
+        </span>
+      </span>
+      <span class="error repository-required">
+        We don’t support that file type.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again</span> with a GIF, JPEG, JPG, MOV, MP4, PNG, SVG, WEBM or WEBP.
+        </span>
+      </span>
+      <span class="error too-big js-upload-too-big">
+      </span>
+      <span class="error empty">
+        This file is empty.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again</span> with a file that’s not empty.
+        </span>
+      </span>
+      <span class="error hidden-file">
+        This file is hidden.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again</span> with another file.
+        </span>
+      </span>
+      <span class="error failed-request">
+        Something went really wrong, and we can’t process that file.
+        <span class="drag-and-drop-error-info">
+          <span class="btn-link">Try again.</span>
+        </span>
+      </span>
+    </span>
+    <a
+      class="Link--muted position-relative d-inline"
+      href="https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax"
+      target="_blank"
+      data-ga-click="Markdown Toolbar, click, help"
+      id="dd_wiki-fileupload_md_link"
+      
+    >
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-markdown v-align-bottom">
+    <path d="M14.85 3c.63 0 1.15.52 1.14 1.15v7.7c0 .63-.51 1.15-1.15 1.15H1.15C.52 13 0 12.48 0 11.84V4.15C0 3.52.52 3 1.15 3ZM9 11V5H7L5.5 7 4 5H2v6h2V8l1.5 1.92L7 8v3Zm2.99.5L14.5 8H13V5h-2v3H9.5Z"></path>
+</svg>
+    </a>
+    <tool-tip id="tooltip-54ebc0ed-a2bd-4441-b2f1-70ecbe0ef4c3" for="dd_wiki-fileupload_md_link" popover="manual" data-direction="nw" data-type="label" data-view-component="true" class="sr-only position-absolute">Styling with Markdown is supported</tool-tip>
+  </label>
+
+    </div>
+</file-attachment>
+  <div class="m-0 preview-content">
+    <div class="px-0 pt-1 pb-3 comment-body js-comment-body js-preview-body"></div>
+  </div>
+
+</div>
+
+  <div id="gollum-editor-edit-summary" class="my-4">
+    <label class="d-block mb-2 jaws" for="gollum-editor-message-field">Edit message</label>
+    <input type="text" name="wiki[commit]" id="gollum-editor-message-field" value="" placeholder="Write a small message here explaining this change. (Optional)" class="form-control input-block" />
+  </div>
+
+<div class="form-actions d-flex d-md-block">
+    <button type="submit" class="flex-auto btn btn-primary" id="gollum-editor-submit" data-disable-with>Save page</button>
+</div>
+
+<input class="form-control" type="text" name="required_field_2311" hidden="hidden" />
+<input class="form-control" type="hidden" name="timestamp" value="1759164683647" />
+<input class="form-control" type="hidden" name="timestamp_secret" value="bc8f59a26984136f938afef460366a7bafe95d89f937fba2a94e5fd796847a89" />
+
+
+</form>      </div>
+    </div>
+  </div>
+
+
+  </div>
+
+</turbo-frame>
+
+
+
+    </main>
+  </div>
+
+  </div>
+
+          <footer class="footer pt-8 pb-6 f6 color-fg-muted p-responsive" role="contentinfo" >
+  <h2 class='sr-only'>Footer</h2>
+
+  
+
+
+  <div class="d-flex flex-justify-center flex-items-center flex-column-reverse flex-lg-row flex-wrap flex-lg-nowrap">
+    <div class="d-flex flex-items-center flex-shrink-0 mx-2">
+      <a aria-label="GitHub Homepage" class="footer-octicon mr-2" href="https://github.com">
+        <svg aria-hidden="true" height="24" viewBox="0 0 24 24" version="1.1" width="24" data-view-component="true" class="octicon octicon-mark-github">
+    <path d="M12 1C5.923 1 1 5.923 1 12c0 4.867 3.149 8.979 7.521 10.436.55.096.756-.233.756-.522 0-.262-.013-1.128-.013-2.049-2.764.509-3.479-.674-3.699-1.292-.124-.317-.66-1.293-1.127-1.554-.385-.207-.936-.715-.014-.729.866-.014 1.485.797 1.691 1.128.99 1.663 2.571 1.196 3.204.907.096-.715.385-1.196.701-1.471-2.448-.275-5.005-1.224-5.005-5.432 0-1.196.426-2.186 1.128-2.956-.111-.275-.496-1.402.11-2.915 0 0 .921-.288 3.024 1.128a10.193 10.193 0 0 1 2.75-.371c.936 0 1.871.123 2.75.371 2.104-1.43 3.025-1.128 3.025-1.128.605 1.513.221 2.64.111 2.915.701.77 1.127 1.747 1.127 2.956 0 4.222-2.571 5.157-5.019 5.432.399.344.743 1.004.743 2.035 0 1.471-.014 2.654-.014 3.025 0 .289.206.632.756.522C19.851 20.979 23 16.854 23 12c0-6.077-4.922-11-11-11Z"></path>
+</svg>
+</a>
+      <span>
+        &copy; 2025 GitHub,&nbsp;Inc.
+      </span>
+    </div>
+
+    <nav aria-label="Footer">
+      <h3 class="sr-only" id="sr-footer-heading">Footer navigation</h3>
+
+      <ul class="list-style-none d-flex flex-justify-center flex-wrap mb-2 mb-lg-0" aria-labelledby="sr-footer-heading">
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to Terms&quot;,&quot;label&quot;:&quot;text:terms&quot;}" href="https://docs.github.com/site-policy/github-terms/github-terms-of-service" data-view-component="true" class="Link--secondary Link">Terms</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to privacy&quot;,&quot;label&quot;:&quot;text:privacy&quot;}" href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement" data-view-component="true" class="Link--secondary Link">Privacy</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to security&quot;,&quot;label&quot;:&quot;text:security&quot;}" href="https://github.com/security" data-view-component="true" class="Link--secondary Link">Security</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to status&quot;,&quot;label&quot;:&quot;text:status&quot;}" href="https://www.githubstatus.com/" data-view-component="true" class="Link--secondary Link">Status</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to community&quot;,&quot;label&quot;:&quot;text:community&quot;}" href="https://github.community/" data-view-component="true" class="Link--secondary Link">Community</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to docs&quot;,&quot;label&quot;:&quot;text:docs&quot;}" href="https://docs.github.com/" data-view-component="true" class="Link--secondary Link">Docs</a>
+          </li>
+
+          <li class="mx-2">
+            <a data-analytics-event="{&quot;category&quot;:&quot;Footer&quot;,&quot;action&quot;:&quot;go to contact&quot;,&quot;label&quot;:&quot;text:contact&quot;}" href="https://support.github.com?tags=dotcom-footer" data-view-component="true" class="Link--secondary Link">Contact</a>
+          </li>
+
+          <li class="mx-2" >
+  <cookie-consent-link>
+    <button
+      type="button"
+      class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent"
+      data-action="click:cookie-consent-link#showConsentManagement"
+      data-analytics-event="{&quot;location&quot;:&quot;footer&quot;,&quot;action&quot;:&quot;cookies&quot;,&quot;context&quot;:&quot;subfooter&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;cookies_link_subfooter_footer&quot;}"
+    >
+       Manage cookies
+    </button>
+  </cookie-consent-link>
+</li>
+
+<li class="mx-2">
+  <cookie-consent-link>
+    <button
+      type="button"
+      class="Link--secondary underline-on-hover border-0 p-0 color-bg-transparent text-left"
+      data-action="click:cookie-consent-link#showConsentManagement"
+      data-analytics-event="{&quot;location&quot;:&quot;footer&quot;,&quot;action&quot;:&quot;dont_share_info&quot;,&quot;context&quot;:&quot;subfooter&quot;,&quot;tag&quot;:&quot;link&quot;,&quot;label&quot;:&quot;dont_share_info_link_subfooter_footer&quot;}"
+    >
+      Do not share my personal information
+    </button>
+  </cookie-consent-link>
+</li>
+
+      </ul>
+    </nav>
+  </div>
+</footer>
+
+
+
+    <ghcc-consent id="ghcc" class="position-fixed bottom-0 left-0" style="z-index: 999999"
+      data-locale="en"
+      data-initial-cookie-consent-allowed=""
+      data-cookie-consent-required="false"
+    ></ghcc-consent>
+
+
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error" hidden>
+    <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-alert">
+    <path d="M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"></path>
+</svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+    <template id="site-details-dialog">
+  <details class="details-reset details-overlay details-overlay-dark lh-default color-fg-default hx_rsm" open>
+    <summary role="button" aria-label="Close dialog"></summary>
+    <details-dialog class="Box Box--overlay d-flex flex-column anim-fade-in fast hx_rsm-dialog hx_rsm-modal">
+      <button class="Box-btn-octicon m-0 btn-octicon position-absolute right-0 top-0" type="button" aria-label="Close dialog" data-close-dialog>
+        <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-x">
+    <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z"></path>
+</svg>
+      </button>
+      <div class="octocat-spinner my-6 js-details-dialog-spinner"></div>
+    </details-dialog>
+  </details>
+</template>
+
+    <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box color-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+    <template id="snippet-clipboard-copy-button">
+  <div class="zeroclipboard-container position-absolute right-0 top-0">
+    <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0" data-copy-feedback="Copied!" data-tooltip-direction="w">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+</svg>
+    </clipboard-copy>
+  </div>
+</template>
+<template id="snippet-clipboard-copy-button-unpositioned">
+  <div class="zeroclipboard-container">
+    <clipboard-copy aria-label="Copy" class="ClipboardButton btn btn-invisible js-clipboard-copy m-2 p-0 d-flex flex-justify-center flex-items-center" data-copy-feedback="Copied!" data-tooltip-direction="w">
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon">
+    <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path>
+</svg>
+      <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none">
+    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path>
+</svg>
+    </clipboard-copy>
+  </div>
+</template>
+
+
+
+
+    </div>
+    <div id="js-global-screen-reader-notice" class="sr-only mt-n1" aria-live="polite" aria-atomic="true" ></div>
+    <div id="js-global-screen-reader-notice-assertive" class="sr-only mt-n1" aria-live="assertive" aria-atomic="true"></div>
+  </body>
+</html>
+


### PR DESCRIPTION
## Summary
- extend the plugin manager with lazy module proxies and automatically expose every repository module
- load the StSLib runtime next to BaseMod, provide a unified Python façade for actions/keywords/modifiers, and expose helper APIs to plugins
- update bundling defaults to include StSLib dependencies and capture new StSLib research notes for future automation work

## Testing
- python -m compileall modules plugins.py

------
https://chatgpt.com/codex/tasks/task_e_68dab8f7cf888327a3b324dd7ebe9a19