### PR TITLE
Add simple card blueprint helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ directly to Python developers.
 - Repository wide plugin manager that exposes every module to third party
   extensions.
 - High level project system for declaring characters, card colours and cards via `ModProject`.
+- Declarative `SimpleCardBlueprint` helper that builds everyday attacks, skills and powers without boilerplate.
 - Turn-key bundling through `compileandbundle` which writes ModTheSpire manifests, Java enum patches and copies Python assets.
 - Forward-looking roadmap documented in `futures.md`.
 

--- a/futures.md
+++ b/futures.md
@@ -26,6 +26,12 @@ Cache inspected Java method signatures to speed up repeated calls to heavily
 used BaseMod hooks.  Usage: extend ``JavaCallableWrapper`` with a lookup table so
 plugins do not incur repeated reflection overhead.
 
+## Advanced simple card effects
+
+Extend `SimpleCardBlueprint` with multi-target power routing, secondary magic numbers and optional follow-up actions.
+Usage: allow blueprint authors to declare additional `effects` in sequence, plus hooks for `on_draw` and
+`on_discard` so heavily scripted cards can still be described declaratively.
+
 ## LimeWire decryption pipeline
 
 Build a Python implementation of the LimeWire content decrypter so that the encrypted jars downloaded during bundling can be unwrapped automatically. Usage: mirror the `GE#getContentItemDecryptionKeys` flow in Python, deriving AES keys from the passphrase and decrypting the AES-CTR stream into usable game jars.

--- a/modules/basemod_wrapper/README.md
+++ b/modules/basemod_wrapper/README.md
@@ -161,6 +161,128 @@ class RevenantStrike(basemod.abstracts.CustomCard):
 
 Because the wrapper already exposes all Java packages, card code reads like a native Python module.
 
+## One-liner cards via simple blueprints
+
+When you only need straightforward cards (deal damage, gain Block, apply a debuff or grant a power) the
+`SimpleCardBlueprint` helper removes all boilerplate. Each blueprint captures the fields you would normally enter
+in the custom card constructor:
+
+1. `title` — the display name of the card.
+1. `description` — freeform text. The placeholders `{damage}`, `{block}`, `{magic}` or `{value}` will be replaced
+   with the configured numbers so you do not have to hardcode them.
+2. `card_type` — one of `attack`, `skill` or `power`.
+3. `target` — `enemy`, `all_enemies`, `self`, `self_and_enemy` or `none`.
+4. `effect` — for skills and powers choose a standard keyword: `block`, `draw`, `energy`, `strength`, `dexterity`,
+   `artifact`, `focus`, `weak`, `vulnerable`, `frail` or `poison`.
+5. `value` — how much damage, Block or power to grant. `upgrade_value` increases the number on upgrade.
+6. `color_id` — optional. Leave unset to use the project colour or specify `RED`, `GREEN`, `BLUE`, `PURPLE`, etc.
+7. `starter` — flag the card as part of the basic card pool.
+8. `rarity` — `basic`, `common`, `uncommon`, `rare`, `special` or `curse`.
+
+### Attack examples
+
+```python
+from modules.basemod_wrapper import SimpleCardBlueprint
+
+# Single target strike.
+strike = SimpleCardBlueprint(
+    identifier="BuddyStrike",
+    title="Buddy Strike",
+    description="Deal {damage} damage.",
+    cost=1,
+    card_type="attack",
+    target="enemy",
+    rarity="common",
+    value=8,
+    upgrade_value=3,
+    image=PROJECT.resource_path("images/cards/buddy_strike.png"),
+    starter=True,
+)
+
+# All enemy swipe.
+wide_slash = SimpleCardBlueprint(
+    identifier="BuddyWhirl",
+    title="Buddy Whirl",
+    description="Deal {damage} damage to ALL enemies.",
+    cost=2,
+    card_type="attack",
+    target="all_enemies",
+    rarity="uncommon",
+    value=6,
+    upgrade_value=2,
+    attack_effect="slash_horizontal",
+    image=PROJECT.resource_path("images/cards/buddy_whirl.png"),
+)
+
+PROJECT.add_simple_card(strike)
+PROJECT.add_simple_card(wide_slash)
+```
+
+### Skill variations
+
+```python
+# Gain Block.
+guard = SimpleCardBlueprint(
+    identifier="BuddyGuard",
+    title="Buddy Guard",
+    description="Gain {block} Block.",
+    cost=1,
+    card_type="skill",
+    target="self",
+    effect="block",
+    rarity="common",
+    value=12,
+    upgrade_value=4,
+    image=PROJECT.resource_path("images/cards/buddy_guard.png"),
+)
+
+# Apply Weak to an enemy.
+glare = SimpleCardBlueprint(
+    identifier="BuddyGlare",
+    title="Buddy Glare",
+    description="Apply {magic} Weak.",
+    cost=1,
+    card_type="skill",
+    target="enemy",
+    effect="weak",
+    rarity="uncommon",
+    value=2,
+    upgrade_value=1,
+    image=PROJECT.resource_path("images/cards/buddy_glare.png"),
+)
+
+# Hand the blueprints to the project.
+PROJECT.add_simple_card(guard)
+PROJECT.add_simple_card(glare)
+```
+
+### Power setup
+
+```python
+fortify = SimpleCardBlueprint(
+    identifier="BuddyFortify",
+    title="Buddy Fortify",
+    description="At the start of your turn, gain {magic} Strength.",
+    cost=2,
+    card_type="power",
+    target="self",
+    effect="strength",
+    rarity="rare",
+    value=2,
+    upgrade_value=1,
+    image=PROJECT.resource_path("images/cards/buddy_fortify.png"),
+)
+
+# Powers automatically use ApplyPowerAction and understand base-game keywords.
+PROJECT.add_simple_card(fortify)
+```
+
+Each `SimpleCardBlueprint` automatically constructs the `CustomCard` subclass, routes the effect through the
+appropriate `DamageAction`, `GainBlockAction` or `ApplyPowerAction`, and registers the card via `BaseMod.addCard`.
+If you pass `starter=True` the card also lands in the colour's basic pool. For colours outside your mod project set
+`color_id` to one of the base game enums (e.g. `RED` for the Ironclad). Whenever you need more exotic behaviour you
+can still hand craft a class — the blueprints are intentionally small wrappers for the common cases.
+
 ### 5. Load the mod in-game
 
 Your `entrypoint.py` already calls `enable_runtime()`, which in turn registers every BaseMod hook. Import the entrypoint in your development REPL or point your ModTheSpire bootstrapper at it; the character, colour and cards become available instantly.

--- a/modules/basemod_wrapper/__init__.py
+++ b/modules/basemod_wrapper/__init__.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, Optional, Sequence
 
 from .loader import ensure_basemod_environment, ensure_jpype
 from .project import BundleOptions, ModProject, ProjectLayout, compileandbundle, create_project
+from .cards import SimpleCardBlueprint, register_simple_card
 
 ensure_jpype()
 from .proxy import JavaPackageWrapper, create_package_wrapper
@@ -337,6 +338,8 @@ PLUGIN_MANAGER.expose("basemod_dependency_jars", _ENVIRONMENT.dependency_jars)
 PLUGIN_MANAGER.expose("basemod_classpath", _ENVIRONMENT.classpath)
 PLUGIN_MANAGER.expose("create_project", create_project)
 PLUGIN_MANAGER.expose("compileandbundle", compileandbundle)
+PLUGIN_MANAGER.expose("SimpleCardBlueprint", SimpleCardBlueprint)
+PLUGIN_MANAGER.expose("register_simple_card", register_simple_card)
 PLUGIN_MANAGER.expose("ModProject", ModProject)
 PLUGIN_MANAGER.expose("ProjectLayout", ProjectLayout)
 PLUGIN_MANAGER.expose("BundleOptions", BundleOptions)
@@ -357,4 +360,6 @@ __all__ = [
     "BundleOptions",
     "create_project",
     "compileandbundle",
+    "SimpleCardBlueprint",
+    "register_simple_card",
 ]

--- a/modules/basemod_wrapper/cards.py
+++ b/modules/basemod_wrapper/cards.py
@@ -1,0 +1,421 @@
+"""High level helpers for declaring simple Slay the Spire cards."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from importlib import import_module
+from typing import Callable, Dict, Mapping, Optional, Sequence
+
+from plugins import PLUGIN_MANAGER
+
+from .loader import BaseModBootstrapError
+
+
+@lru_cache(maxsize=1)
+def _wrapper_module():
+    return import_module("modules.basemod_wrapper")
+
+
+def _cardcrawl():
+    return getattr(_wrapper_module(), "cardcrawl")
+
+
+def _basemod():
+    return getattr(_wrapper_module(), "basemod")
+
+
+def _spire():
+    return getattr(_wrapper_module(), "spire")
+
+
+_TYPE_ALIASES: Mapping[str, str] = {
+    "attack": "ATTACK",
+    "atk": "ATTACK",
+    "skill": "SKILL",
+    "power": "POWER",
+}
+
+_TARGET_ALIASES: Mapping[str, str] = {
+    "enemy": "ENEMY",
+    "single": "ENEMY",
+    "enemies": "ALL_ENEMY",
+    "all_enemies": "ALL_ENEMY",
+    "aoe": "ALL_ENEMY",
+    "self": "SELF",
+    "self_only": "SELF",
+    "none": "NONE",
+    "self_and_enemy": "SELF_AND_ENEMY",
+    "selfenemy": "SELF_AND_ENEMY",
+    "ally": "SELF",
+    "all": "ALL",
+}
+
+_RARITY_ALIASES: Mapping[str, str] = {
+    "basic": "BASIC",
+    "starter": "BASIC",
+    "common": "COMMON",
+    "uncommon": "UNCOMMON",
+    "rare": "RARE",
+    "special": "SPECIAL",
+    "curse": "CURSE",
+}
+
+_SELF_EFFECTS = {
+    "block",
+    "draw",
+    "energy",
+    "strength",
+    "dexterity",
+    "artifact",
+    "focus",
+}
+
+_ENEMY_EFFECTS = {
+    "weak",
+    "vulnerable",
+    "frail",
+    "poison",
+}
+
+_EFFECT_VALUE_FIELD: Mapping[str, str] = {
+    "block": "block",
+    "draw": "magic",
+    "energy": "magic",
+    "strength": "magic",
+    "dexterity": "magic",
+    "artifact": "magic",
+    "focus": "magic",
+    "weak": "magic",
+    "vulnerable": "magic",
+    "frail": "magic",
+    "poison": "magic",
+}
+
+_POWER_CLASS: Mapping[str, str] = {
+    "strength": "StrengthPower",
+    "dexterity": "DexterityPower",
+    "artifact": "ArtifactPower",
+    "focus": "FocusPower",
+    "weak": "WeakPower",
+    "vulnerable": "VulnerablePower",
+    "frail": "FrailPower",
+    "poison": "PoisonPower",
+}
+
+_ATTACK_EFFECT_ALIASES: Mapping[str, str] = {
+    "slash_diagonal": "SLASH_DIAGONAL",
+    "slash_horizontal": "SLASH_HORIZONTAL",
+    "slash_heavy": "SLASH_HEAVY",
+    "vertical": "SLASH_VERTICAL",
+    "smash": "SMASH",
+    "blunt_light": "BLUNT_LIGHT",
+    "blunt_heavy": "BLUNT_HEAVY",
+    "none": "NONE",
+}
+
+
+def _normalise(value: str) -> str:
+    return value.replace(" ", "").replace("-", "").lower()
+
+
+def _coerce_mapping(value: str, mapping: Mapping[str, str], label: str) -> str:
+    key = _normalise(value)
+    if key in mapping:
+        return mapping[key]
+    candidate = value.strip().upper()
+    if candidate in mapping.values():
+        return candidate
+    raise BaseModBootstrapError(f"Unknown {label} '{value}'.")
+
+
+def _resolve_enum(container: object, name: str, label: str) -> object:
+    try:
+        return getattr(container, name)
+    except AttributeError as exc:  # pragma: no cover - depends on JVM enums
+        raise BaseModBootstrapError(f"Unknown {label} '{name}'.") from exc
+
+
+def _format_description(description: str, value: int, *, field: str) -> str:
+    if "{" not in description:
+        return description
+    values = {
+        "value": value,
+        "damage": value if field == "damage" else 0,
+        "block": value if field == "block" else 0,
+        "magic": value if field == "magic" else 0,
+        "amount": value,
+    }
+    try:
+        return description.format(**values)
+    except Exception:
+        return description
+
+
+def _enqueue_action(action: object) -> None:
+    manager = _cardcrawl().dungeons.AbstractDungeon.actionManager
+    manager.addToBottom(action)
+
+
+def _require_monster(monster: object, target_name: str, effect: str) -> object:
+    if monster is None:
+        raise BaseModBootstrapError(
+            f"Effect '{effect}' requires an enemy target but none was provided for card target '{target_name}'."
+        )
+    return monster
+
+
+@dataclass(slots=True)
+class SimpleCardBlueprint:
+    """Describe the high level properties of a straightforward card."""
+
+    identifier: str
+    title: str
+    description: str
+    cost: int
+    card_type: str
+    target: str
+    rarity: str
+    value: int
+    upgrade_value: int = 0
+    effect: Optional[str] = None
+    image: Optional[str] = None
+    color_id: Optional[str] = None
+    starter: bool = False
+    keywords: Sequence[str] = field(default_factory=tuple)
+    keyword_values: Mapping[str, int] = field(default_factory=dict)
+    attack_effect: str = "SLASH_DIAGONAL"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "identifier", self.identifier)
+        object.__setattr__(self, "card_type", _coerce_mapping(self.card_type, _TYPE_ALIASES, "card type"))
+        object.__setattr__(self, "target", _coerce_mapping(self.target, _TARGET_ALIASES, "card target"))
+        object.__setattr__(self, "rarity", _coerce_mapping(self.rarity, _RARITY_ALIASES, "card rarity"))
+        if self.card_type != "ATTACK":
+            if not self.effect:
+                raise BaseModBootstrapError("Skill and power cards must declare an effect keyword.")
+            normalised = _normalise(self.effect)
+            if normalised not in _EFFECT_VALUE_FIELD:
+                raise BaseModBootstrapError(f"Unsupported effect keyword '{self.effect}'.")
+            object.__setattr__(self, "effect", normalised)
+        else:
+            object.__setattr__(self, "effect", None)
+        if isinstance(self.keywords, str):
+            object.__setattr__(self, "keywords", (self.keywords,))
+        else:
+            object.__setattr__(self, "keywords", tuple(self.keywords))
+        attack_effect = _coerce_mapping(self.attack_effect, _ATTACK_EFFECT_ALIASES, "attack effect")
+        object.__setattr__(self, "attack_effect", attack_effect)
+
+    @property
+    def value_field(self) -> str:
+        if self.card_type == "ATTACK":
+            return "damage"
+        if not self.effect:
+            return "magic"
+        return _EFFECT_VALUE_FIELD[self.effect]
+
+
+class SimpleCardFactory:
+    """Construct :class:`CustomCard` subclasses from blueprints."""
+
+    def __init__(self, blueprint: SimpleCardBlueprint, project: "ModProject") -> None:
+        self.blueprint = blueprint
+        self.project = project
+
+    def build_factory(self) -> Callable[[], object]:
+        card_class = self._build_card_class()
+
+        def factory() -> object:
+            color = self._resolve_color()
+            return card_class(color)
+
+        return factory
+
+    # ------------------------------------------------------------------
+    def _resolve_color(self) -> object:
+        if self.blueprint.color_id:
+            CardColor = _cardcrawl().cards.AbstractCard.CardColor
+            return _resolve_enum(CardColor, self.blueprint.color_id, "card color")
+        color_enum = getattr(self.project, "_color_enum", None)
+        if color_enum is not None:
+            return color_enum
+        if hasattr(self.project, "runtime_color_enum"):
+            return self.project.runtime_color_enum()
+        raise BaseModBootstrapError(
+            "No card colour available. Define a colour or set 'color_id' on the blueprint."
+        )
+
+    def _build_card_class(self) -> type:
+        blueprint = self.blueprint
+        cardcrawl = _cardcrawl()
+        basemod = _basemod()
+
+        CardType = cardcrawl.cards.AbstractCard.CardType
+        CardTarget = cardcrawl.cards.AbstractCard.CardTarget
+        CardRarity = cardcrawl.cards.AbstractCard.CardRarity
+
+        card_type = _resolve_enum(CardType, blueprint.card_type, "card type")
+        card_target = _resolve_enum(CardTarget, blueprint.target, "card target")
+        card_rarity = _resolve_enum(CardRarity, blueprint.rarity, "card rarity")
+
+        if blueprint.card_type == "ATTACK" and blueprint.target not in {"ENEMY", "ALL_ENEMY"}:
+            raise BaseModBootstrapError("Attack cards must target ENEMY or ALL_ENEMY when using the simple factory.")
+        if blueprint.effect in _SELF_EFFECTS and blueprint.target not in {"SELF", "SELF_AND_ENEMY", "ALL"}:
+            raise BaseModBootstrapError(
+                f"Effect '{blueprint.effect}' requires a self-facing target (SELF or SELF_AND_ENEMY)."
+            )
+        if blueprint.effect in _ENEMY_EFFECTS and blueprint.target not in {"ENEMY", "SELF_AND_ENEMY"}:
+            raise BaseModBootstrapError(
+                f"Effect '{blueprint.effect}' requires an enemy-facing target (ENEMY or SELF_AND_ENEMY)."
+            )
+
+        image_path = blueprint.image or self.project.resource_path(f"images/cards/{blueprint.identifier}.png")
+        value_field = blueprint.value_field
+        attack_effect = _resolve_enum(
+            cardcrawl.actions.AbstractGameAction.AttackEffect, blueprint.attack_effect, "attack effect"
+        )
+
+        keyword_settings: Dict[str, int] = {k: int(v) for k, v in blueprint.keyword_values.items()}
+
+        class GeneratedCard(basemod.abstracts.CustomCard):  # type: ignore[misc]
+            ID = blueprint.identifier
+            IMG = image_path
+            COST = blueprint.cost
+
+            def __init__(self, color: object) -> None:
+                description = _format_description(blueprint.description, blueprint.value, field=value_field)
+                super().__init__(
+                    self.ID,
+                    blueprint.title,
+                    self.IMG,
+                    blueprint.cost,
+                    description,
+                    card_type,
+                    color,
+                    card_rarity,
+                    card_target,
+                )
+                self._simple_blueprint = blueprint
+                self.simple_color = color
+                if value_field == "damage":
+                    self.baseDamage = blueprint.value
+                    self.damage = blueprint.value
+                    if blueprint.target == "ALL_ENEMY":
+                        self.isMultiDamage = True
+                elif value_field == "block":
+                    self.baseBlock = blueprint.value
+                    self.block = blueprint.value
+                else:
+                    self.baseMagicNumber = blueprint.value
+                    self.magicNumber = blueprint.value
+                if blueprint.target == "ALL_ENEMY":
+                    self.damageTypeForTurn = cardcrawl.cards.DamageInfo.DamageType.NORMAL
+                if blueprint.keywords:
+                    spire_api = _spire()
+                    for keyword in blueprint.keywords:
+                        settings = {}
+                        if keyword in keyword_settings:
+                            settings["amount"] = keyword_settings[keyword]
+                        spire_api.apply_keyword(self, keyword, amount=settings.get("amount"))
+                self.initializeDescription()
+
+            def use(self, player: object, monster: Optional[object]) -> None:
+                if blueprint.card_type == "ATTACK":
+                    _play_attack(self, player, monster, blueprint, attack_effect)
+                else:
+                    _play_effect(self, player, monster, blueprint)
+
+            def upgrade(self) -> None:
+                if not self.upgraded:
+                    self.upgradeName()
+                    if blueprint.upgrade_value:
+                        if value_field == "damage":
+                            self.upgradeDamage(blueprint.upgrade_value)
+                        elif value_field == "block":
+                            self.upgradeBlock(blueprint.upgrade_value)
+                        else:
+                            self.upgradeMagicNumber(blueprint.upgrade_value)
+                    self.initializeDescription()
+
+            def makeCopy(self):
+                return type(self)(self.simple_color)
+
+        GeneratedCard.__name__ = f"{blueprint.identifier}Card"
+        return GeneratedCard
+
+
+def _play_attack(card: object, player: object, monster: Optional[object], blueprint: SimpleCardBlueprint, attack_effect: object) -> None:
+    cardcrawl = _cardcrawl()
+    actions = cardcrawl.actions.common
+    DamageInfo = cardcrawl.cards.DamageInfo
+    if blueprint.target == "ALL_ENEMY":
+        amounts = getattr(card, "multiDamage", None)
+        if not amounts:
+            amounts = [card.damage]
+        action = actions.DamageAllEnemiesAction(
+            player,
+            amounts,
+            card.damageTypeForTurn,
+            attack_effect,
+        )
+    else:
+        monster = _require_monster(monster, blueprint.target, "attack")
+        info = DamageInfo(player, card.damage, card.damageTypeForTurn)
+        action = actions.DamageAction(monster, info, attack_effect)
+    _enqueue_action(action)
+
+
+def _play_effect(card: object, player: object, monster: Optional[object], blueprint: SimpleCardBlueprint) -> None:
+    effect = blueprint.effect
+    if effect is None:
+        return
+    cardcrawl = _cardcrawl()
+    actions = cardcrawl.actions.common
+    powers = cardcrawl.powers
+    if effect == "block":
+        action = actions.GainBlockAction(player, player, card.block)
+        _enqueue_action(action)
+        return
+    if effect == "draw":
+        action = actions.DrawCardAction(player, card.magicNumber)
+        _enqueue_action(action)
+        return
+    if effect == "energy":
+        action = actions.GainEnergyAction(card.magicNumber)
+        _enqueue_action(action)
+        return
+    if effect in {"strength", "dexterity", "artifact", "focus"}:
+        owner = player
+        power_cls = getattr(powers, _POWER_CLASS[effect])
+        power = power_cls(owner, card.magicNumber)
+        action = actions.ApplyPowerAction(owner, player, power, card.magicNumber)
+        _enqueue_action(action)
+        return
+    monster = _require_monster(monster, blueprint.target, effect)
+    if effect == "poison":
+        power_cls = getattr(powers, _POWER_CLASS[effect])
+        power = power_cls(monster, player, card.magicNumber)
+        action = actions.ApplyPowerAction(monster, player, power, card.magicNumber)
+        _enqueue_action(action)
+        return
+    if effect in {"weak", "vulnerable", "frail"}:
+        power_cls = getattr(powers, _POWER_CLASS[effect])
+        power = power_cls(monster, card.magicNumber, False)
+        action = actions.ApplyPowerAction(monster, player, power, card.magicNumber)
+        _enqueue_action(action)
+        return
+    raise BaseModBootstrapError(f"Unhandled effect '{effect}'.")
+
+
+def register_simple_card(project: "ModProject", blueprint: SimpleCardBlueprint) -> None:
+    """Register ``blueprint`` against ``project`` using the simple factory."""
+
+    factory = SimpleCardFactory(blueprint, project).build_factory()
+    project.add_card(blueprint.identifier, factory, basic=blueprint.starter)
+
+
+PLUGIN_MANAGER.expose("SimpleCardBlueprint", SimpleCardBlueprint)
+PLUGIN_MANAGER.expose("register_simple_card", register_simple_card)
+PLUGIN_MANAGER.expose_module("modules.basemod_wrapper.cards", alias="basemod_cards")
+
+__all__ = ["SimpleCardBlueprint", "SimpleCardFactory", "register_simple_card"]

--- a/research/sts_base_keywords.md
+++ b/research/sts_base_keywords.md
@@ -1,0 +1,19 @@
+# Slay the Spire base game keyword quick reference
+
+Source: https://slay-the-spire.fandom.com/wiki/Keyword (retrieved 2024-05-29)
+
+| Keyword | Typical effect | Common usage |
+| --- | --- | --- |
+| Block | Prevent incoming damage until the end of the turn. | Awarded by defensive skills like "Defend"; scales with Dexterity. |
+| Strength | Increases outgoing attack damage by the granted amount. | Applied by cards like "Inflame" and "Spot Weakness". |
+| Dexterity | Increases Block gained from cards by the granted amount. | Granted by cards like "Leg Sweep" and powers like "Footwork". |
+| Focus | Increases Orb passive and evoke effects. | Used by Defect powers such as "Defragment". |
+| Artifact | Negates a single debuff for each stack. | Provided by cards like "Panacea" or relics like "Orichalcum". |
+| Energy | Extra energy for the current turn. | Granted by skills like "Adrenaline". |
+| Card Draw | Draw additional cards immediately. | Enabled by cards like "Battle Trance". |
+| Weak | Debuff that reduces enemy attack damage by 25%. | Applied by cards like "Leg Sweep" or "Crippling Cloud". |
+| Vulnerable | Debuff increasing damage taken by 50%. | Applied by cards like "Bash" or "Uppercut". |
+| Frail | Debuff reducing Block gain by 25%. | Applied by cards like "Crippling Cloud". |
+| Poison | Deals damage at the end of the victim's turn and decreases each tick. | Applied by Silent cards like "Deadly Poison". |
+
+These are the core keywords most frequently referenced when scripting straightforward powers or skills. They map cleanly to `ApplyPowerAction` invocations when writing automation helpers.

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.loader import BaseModBootstrapError
+from modules.basemod_wrapper.project import ModProject
+
+
+class StubActionManager:
+    def __init__(self) -> None:
+        self.actions = []
+
+    def addToBottom(self, action) -> None:
+        self.actions.append(action)
+
+    def pop(self):
+        return self.actions.pop(0)
+
+    def clear(self) -> None:
+        self.actions.clear()
+
+
+class StubDamageAction:
+    def __init__(self, target, info, effect) -> None:
+        self.target = target
+        self.info = info
+        self.effect = effect
+
+
+class StubDamageAllEnemiesAction:
+    def __init__(self, player, amounts, damage_type, effect) -> None:
+        self.player = player
+        self.amounts = list(amounts)
+        self.damage_type = damage_type
+        self.effect = effect
+
+
+class StubGainBlockAction:
+    def __init__(self, target, source, amount) -> None:
+        self.target = target
+        self.source = source
+        self.amount = amount
+
+
+class StubDrawCardAction:
+    def __init__(self, player, amount) -> None:
+        self.player = player
+        self.amount = amount
+
+
+class StubGainEnergyAction:
+    def __init__(self, amount) -> None:
+        self.amount = amount
+
+
+class StubApplyPowerAction:
+    def __init__(self, target, source, power, amount) -> None:
+        self.target = target
+        self.source = source
+        self.power = power
+        self.amount = amount
+
+
+class StubDamageInfo:
+    class DamageType:
+        NORMAL = "NORMAL"
+
+    def __init__(self, source, amount, damage_type) -> None:
+        self.source = source
+        self.base = amount
+        self.output = amount
+        self.type = damage_type
+
+
+class StubCustomCard:
+    def __init__(self, card_id, name, img, cost, description, card_type, color, rarity, target) -> None:
+        self.cardID = card_id
+        self.name = name
+        self.rawDescription = description
+        self.cost = cost
+        self.type = card_type
+        self.color = color
+        self.rarity = rarity
+        self.target = target
+        self.baseDamage = 0
+        self.damage = 0
+        self.baseBlock = 0
+        self.block = 0
+        self.baseMagicNumber = 0
+        self.magicNumber = 0
+        self.multiDamage = []
+        self.damageTypeForTurn = StubDamageInfo.DamageType.NORMAL
+        self.isMultiDamage = False
+        self.upgraded = False
+
+    def initializeDescription(self) -> None:
+        self.description = self.rawDescription
+
+    def upgradeName(self) -> None:
+        self.upgraded = True
+
+    def upgradeDamage(self, amount: int) -> None:
+        self.baseDamage += amount
+        self.damage = self.baseDamage
+
+    def upgradeBlock(self, amount: int) -> None:
+        self.baseBlock += amount
+        self.block = self.baseBlock
+
+    def upgradeMagicNumber(self, amount: int) -> None:
+        self.baseMagicNumber += amount
+        self.magicNumber = self.baseMagicNumber
+
+
+class StubStrengthPower:
+    def __init__(self, owner, amount) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.name = "Strength"
+
+
+class StubWeakPower:
+    def __init__(self, owner, amount, is_source_monster) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.is_source_monster = is_source_monster
+        self.name = "Weak"
+
+
+class StubPoisonPower:
+    def __init__(self, owner, source, amount) -> None:
+        self.owner = owner
+        self.source = source
+        self.amount = amount
+        self.name = "Poison"
+
+
+class StubDexterityPower:
+    def __init__(self, owner, amount) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.name = "Dexterity"
+
+
+class StubArtifactPower:
+    def __init__(self, owner, amount) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.name = "Artifact"
+
+
+class StubFocusPower:
+    def __init__(self, owner, amount) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.name = "Focus"
+
+
+class StubVulnerablePower:
+    def __init__(self, owner, amount, is_source_monster) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.is_source_monster = is_source_monster
+        self.name = "Vulnerable"
+
+
+class StubFrailPower:
+    def __init__(self, owner, amount, is_source_monster) -> None:
+        self.owner = owner
+        self.amount = amount
+        self.is_source_monster = is_source_monster
+        self.name = "Frail"
+
+
+class StubCardColor:
+    RED = "RED"
+    GREEN = "GREEN"
+    BLUE = "BLUE"
+    PURPLE = "PURPLE"
+
+    @staticmethod
+    def valueOf(name: str):
+        return getattr(StubCardColor, name)
+
+
+class StubSpire:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def apply_keyword(self, card, keyword, *, amount=None) -> None:
+        self.calls.append((card, keyword, amount))
+
+
+@pytest.fixture()
+def stubbed_runtime(monkeypatch):
+    action_manager = StubActionManager()
+    attack_effects = SimpleNamespace(
+        SLASH_DIAGONAL="SLASH_DIAGONAL",
+        SLASH_HORIZONTAL="SLASH_HORIZONTAL",
+        NONE="NONE",
+    )
+    abstract_card = SimpleNamespace(
+        CardType=SimpleNamespace(ATTACK="ATTACK", SKILL="SKILL", POWER="POWER"),
+        CardTarget=SimpleNamespace(
+            ENEMY="ENEMY",
+            ALL_ENEMY="ALL_ENEMY",
+            SELF="SELF",
+            SELF_AND_ENEMY="SELF_AND_ENEMY",
+            NONE="NONE",
+            ALL="ALL",
+        ),
+        CardRarity=SimpleNamespace(
+            BASIC="BASIC",
+            COMMON="COMMON",
+            UNCOMMON="UNCOMMON",
+            RARE="RARE",
+            SPECIAL="SPECIAL",
+            CURSE="CURSE",
+        ),
+        CardColor=StubCardColor,
+    )
+    cards_namespace = SimpleNamespace(AbstractCard=abstract_card, DamageInfo=StubDamageInfo)
+    common_actions = SimpleNamespace(
+        DamageAction=StubDamageAction,
+        DamageAllEnemiesAction=StubDamageAllEnemiesAction,
+        GainBlockAction=StubGainBlockAction,
+        DrawCardAction=StubDrawCardAction,
+        GainEnergyAction=StubGainEnergyAction,
+        ApplyPowerAction=StubApplyPowerAction,
+    )
+    actions_namespace = SimpleNamespace(AbstractGameAction=SimpleNamespace(AttackEffect=attack_effects), common=common_actions)
+    powers_namespace = SimpleNamespace(
+        StrengthPower=StubStrengthPower,
+        WeakPower=StubWeakPower,
+        PoisonPower=StubPoisonPower,
+        DexterityPower=StubDexterityPower,
+        ArtifactPower=StubArtifactPower,
+        FocusPower=StubFocusPower,
+        VulnerablePower=StubVulnerablePower,
+        FrailPower=StubFrailPower,
+    )
+    dungeon_namespace = SimpleNamespace(AbstractDungeon=SimpleNamespace(actionManager=action_manager))
+    cardcrawl_stub = SimpleNamespace(
+        cards=cards_namespace,
+        actions=actions_namespace,
+        powers=powers_namespace,
+        dungeons=dungeon_namespace,
+    )
+    spire_stub = StubSpire()
+    basemod_stub = SimpleNamespace(abstracts=SimpleNamespace(CustomCard=StubCustomCard))
+
+    from modules.basemod_wrapper import cards as cards_module
+
+    monkeypatch.setattr(cards_module, "_cardcrawl", lambda: cardcrawl_stub)
+    monkeypatch.setattr(cards_module, "_basemod", lambda: basemod_stub)
+    monkeypatch.setattr(cards_module, "_spire", lambda: spire_stub)
+
+    yield cardcrawl_stub, action_manager, spire_stub
+
+    action_manager.clear()
+    spire_stub.calls.clear()
+
+
+def test_attack_blueprint_registers_basic_card(stubbed_runtime):
+    _, action_manager, _ = stubbed_runtime
+    project = ModProject("buddy", "Buddy Mod", "Buddy", "Testing")
+    project._color_enum = "BUDDY_COLOR"
+
+    blueprint = SimpleCardBlueprint(
+        identifier="BuddyStrike",
+        title="Buddy Strike",
+        description="Deal {damage} damage.",
+        cost=1,
+        card_type="attack",
+        target="enemy",
+        rarity="common",
+        value=9,
+        upgrade_value=4,
+        starter=True,
+        image="buddy/images/cards/strike.png",
+    )
+    project.add_simple_card(blueprint)
+
+    registration = project.cards["BuddyStrike"]
+    assert registration.make_basic is True
+
+    card = registration.factory()
+    player = object()
+    monster = object()
+    card.use(player, monster)
+    action = action_manager.pop()
+    assert isinstance(action, StubDamageAction)
+    assert action.target is monster
+    assert action.info.base == 9
+
+    card.upgrade()
+    assert card.damage == 13
+
+
+def test_attack_all_enemies_uses_multidamage(stubbed_runtime):
+    cardcrawl_stub, action_manager, _ = stubbed_runtime
+    project = ModProject("buddy", "Buddy Mod", "Buddy", "Testing")
+    project._color_enum = "BUDDY_COLOR"
+
+    blueprint = SimpleCardBlueprint(
+        identifier="BuddyWhirl",
+        title="Buddy Whirl",
+        description="Deal {damage} damage to ALL enemies.",
+        cost=2,
+        card_type="attack",
+        target="all_enemies",
+        rarity="uncommon",
+        value=6,
+        image="buddy/images/cards/whirl.png",
+        attack_effect="slash_horizontal",
+    )
+    project.add_simple_card(blueprint)
+    card = project.cards["BuddyWhirl"].factory()
+
+    player = object()
+    card.use(player, None)
+    action = action_manager.pop()
+    assert isinstance(action, StubDamageAllEnemiesAction)
+    assert action.player is player
+    assert action.amounts == [6]
+    assert action.effect == cardcrawl_stub.actions.AbstractGameAction.AttackEffect.SLASH_HORIZONTAL
+
+
+def test_skill_and_power_effects(stubbed_runtime):
+    _, action_manager, spire_stub = stubbed_runtime
+    project = ModProject("buddy", "Buddy Mod", "Buddy", "Testing")
+    project._color_enum = "BUDDY_COLOR"
+
+    block_blueprint = SimpleCardBlueprint(
+        identifier="BuddyGuard",
+        title="Buddy Guard",
+        description="Gain {block} Block.",
+        cost=1,
+        card_type="skill",
+        target="self",
+        effect="block",
+        rarity="common",
+        value=12,
+        upgrade_value=4,
+        keywords=("retain",),
+        keyword_values={"retain": 1},
+        image="buddy/images/cards/guard.png",
+    )
+    project.add_simple_card(block_blueprint)
+    block_card = project.cards["BuddyGuard"].factory()
+    player = object()
+    block_card.use(player, None)
+    block_action = action_manager.pop()
+    assert isinstance(block_action, StubGainBlockAction)
+    assert block_action.amount == 12
+    assert spire_stub.calls[0][1] == "retain"
+
+    weak_blueprint = SimpleCardBlueprint(
+        identifier="BuddyGlare",
+        title="Buddy Glare",
+        description="Apply {magic} Weak.",
+        cost=1,
+        card_type="skill",
+        target="enemy",
+        effect="weak",
+        rarity="uncommon",
+        value=2,
+        image="buddy/images/cards/glare.png",
+    )
+    project.add_simple_card(weak_blueprint)
+    weak_card = project.cards["BuddyGlare"].factory()
+    monster = object()
+    weak_card.use(player, monster)
+    weak_action = action_manager.pop()
+    assert isinstance(weak_action, StubApplyPowerAction)
+    assert weak_action.amount == 2
+    assert weak_action.power.name == "Weak"
+
+    power_blueprint = SimpleCardBlueprint(
+        identifier="BuddyFortify",
+        title="Buddy Fortify",
+        description="Gain {magic} Strength each turn.",
+        cost=2,
+        card_type="power",
+        target="self",
+        effect="strength",
+        rarity="rare",
+        value=2,
+        image="buddy/images/cards/fortify.png",
+    )
+    project.add_simple_card(power_blueprint)
+    power_card = project.cards["BuddyFortify"].factory()
+    power_card.use(player, None)
+    power_action = action_manager.pop()
+    assert power_action.power.name == "Strength"
+    assert power_action.amount == 2
+
+
+def test_color_override_uses_card_enum(stubbed_runtime):
+    _, _, _ = stubbed_runtime
+    project = ModProject("buddy", "Buddy Mod", "Buddy", "Testing")
+
+    blueprint = SimpleCardBlueprint(
+        identifier="BuddyBolt",
+        title="Buddy Bolt",
+        description="Deal {damage} damage.",
+        cost=1,
+        card_type="attack",
+        target="enemy",
+        rarity="common",
+        value=7,
+        color_id="RED",
+        image="buddy/images/cards/bolt.png",
+    )
+    project.add_simple_card(blueprint)
+    card = project.cards["BuddyBolt"].factory()
+    assert card.color == StubCardColor.RED
+
+
+def test_invalid_skill_without_effect_raises(stubbed_runtime):
+    with pytest.raises(BaseModBootstrapError):
+        SimpleCardBlueprint(
+            identifier="InvalidSkill",
+            title="Invalid",
+            description="No effect",
+            cost=1,
+            card_type="skill",
+            target="self",
+            rarity="common",
+            value=1,
+            image="invalid.png",
+        )


### PR DESCRIPTION
## Summary
- add a SimpleCardBlueprint helper that builds common attack, skill, and power cards with BaseMod actions
- expose the helper through the wrapper package and document usage with worked examples for each card type
- capture base-game keyword research, extend the futures roadmap, and cover the helper with isolated unit tests

## Testing
- pytest tests/test_cards.py

------
https://chatgpt.com/codex/tasks/task_e_68db88eb25c48327bed4bf512fbee31a