### PR TITLE
Require card uses for Exhaustive blueprints

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -57,6 +57,14 @@ common archetypes (e.g. Exhaustive retainers or Persist powers). Usage: expose `
 helpers that merge preset dictionaries into blueprints so mods can opt-in via a single call and plugins can contribute
 additional presets through ``PLUGIN_MANAGER`` broadcasts.
 
+## Generalised dynamic keyword placeholders
+
+Now that Exhaustive cards translate ``{uses}`` into the runtime ``!stslib:ex!`` token automatically, extend the formatter so
+other numeric keywords (Refund, Persist, Fleeting, Soulbound, etc.) can expose intuitive placeholders as well. Usage: build a
+mapping from keyword name to dynamic token within ``_uses_placeholder`` (renamed to a generic helper) and document the supported
+placeholders in the wrapper README. Plugins should be able to contribute additional mappings through a shared registry exposed
+on ``PLUGIN_MANAGER``.
+
 ## ProjectLayout localisation variants
 
 Teach ``ModProject.scaffold`` to generate localisation folders for multiple languages in one go (eng, fra, deu, zhs, etc.) and expose a helper that mirrors ``resource_path`` for localisation files. Usage: extend the scaffold signature with ``languages: Sequence[str]`` and update ``ProjectLayout`` with a mapping from language codes to directories so future tutorials can demonstrate multi-language text packs out of the box.

--- a/modules/basemod_wrapper/README.md
+++ b/modules/basemod_wrapper/README.md
@@ -176,6 +176,7 @@ Each blueprint is a dataclass with the following key fields:
 | `attack_effect` | Visual for damage actions (`slash_diagonal`, `slash_horizontal`, `blunt_heavy`, etc.). |
 | `keywords` | Iterable of keyword flags. Canonical names (`innate`, `retain`, `stslib:Exhaustive`) are normalised automatically. |
 | `keyword_values` / `keyword_upgrades` | Numeric keyword payloads (e.g. Exhaustive counts) and their upgrade deltas. |
+| `card_uses` / `card_uses_upgrade` | Required for Exhaustive cards. Provides the base number of uses (and optional upgrade delta) that will be rendered via `{uses}`. |
 | `image` | Resource path used when you already have card art on disk. |
 | `inner_image_source` | Optional 500x380 image that will be processed into BaseMod-ready portrait/inner art pairs. |
 
@@ -202,7 +203,7 @@ strike = SimpleCardBlueprint(
 guard = SimpleCardBlueprint(
     identifier="RevenantGuard",
     title="Soul Guard",
-    description="Gain {block} Block. Exhaustive !stslib:ex!.",
+    description="Gain {block} Block. Exhaustive {uses}.",
     cost=1,
     card_type="skill",
     target="self",
@@ -211,7 +212,7 @@ guard = SimpleCardBlueprint(
     value=12,
     upgrade_value=4,
     keywords=("innate", "retain", "stslib:Exhaustive"),
-    keyword_values={"exhaustive": 2},
+    card_uses=2,
     keyword_upgrades={"exhaustive": 1},
 )
 
@@ -223,6 +224,10 @@ When registered, the blueprint generates a full `CustomCard` subclass, wires the
 correct BaseMod/StSLib actions (`DamageAction`, `GainBlockAction`,
 `ApplyPowerAction`) and exposes it to the runtime. The resulting card IDs are
 prefixed automatically with your project’s `mod_id`.
+
+Exhaustive blueprints automatically translate the `{uses}` placeholder into the
+`!stslib:ex!` runtime token so players always see the remaining uses without
+sprinkling raw StSLib variables into descriptions.
 
 #### Inner art automation
 


### PR DESCRIPTION
## Summary
- require SimpleCardBlueprint Exhaustive cards to declare `card_uses` and auto-populate keyword values
- translate the `{uses}` placeholder into the StSLib Exhaustive dynamic token and guard against misuse
- document the new Exhaustive workflow and extend tests plus futures roadmap for broader placeholder support

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbb2f82a748327a8205ecfdbeeea98