### PR TITLE
Add documentation for card selection actions

### DIFF
--- a/research/choose_card_interfaces.md
+++ b/research/choose_card_interfaces.md
@@ -1,0 +1,108 @@
+# Card selection flows: hand vs draw pile
+
+## Overview
+
+This note documents how to build two user-driven card selection flows while reusing Slay the Spire's built-in selection screens:
+
+* **ChooseFromHand** – prompt the player to pick one or more cards currently in hand and then run arbitrary follow-up code on the chosen set.
+* **ChooseFromDrawPile** – display the draw pile in a grid selector, let the player pick card(s), and act on the result.
+
+Both patterns rely entirely on existing screen classes (`HandCardSelectScreen` and `GridCardSelectScreen`) and the thin StSLib helper actions that already orchestrate them. Because the Python wrapper ships first-class bindings to those actions, the flows can be triggered directly from Python without writing new Java glue code.
+
+## Prerequisites
+
+* Import the unified wrapper facade and action queue helpers:
+  ```python
+  from modules.basemod_wrapper import spire
+  from modules.basemod_wrapper.cards import _enqueue_action  # or use your own queue helper
+  ```
+* Every action created below must be enqueued (e.g. via `AbstractDungeon.actionManager.addToBottom`). The `_enqueue_action` helper shown above is a thin wrapper around that queue.【F:modules/basemod_wrapper/cards.py†L188-L198】
+
+## ChooseFromHand via `SelectCardsInHandAction`
+
+`SelectCardsInHandAction` opens the vanilla hand-selection screen (`AbstractDungeon.handCardSelectScreen`), filters the hand using a predicate, and feeds the selected cards back to a callback once the player confirms.【F:research/stslib_SelectCardsInHandAction.java†L1-L99】
+
+### Key behaviours
+
+* Filters out cards that fail the predicate before opening the screen and restores them afterwards.【F:research/stslib_SelectCardsInHandAction.java†L55-L93】
+* Supports exact or "any number" picks and optional skip (`canPickZero`).【F:research/stslib_SelectCardsInHandAction.java†L37-L66】
+* Short-circuits when the filtered hand already satisfies the requested amount (e.g. only one eligible card).【F:research/stslib_SelectCardsInHandAction.java†L63-L84】
+
+### Python usage
+
+```python
+from modules.basemod_wrapper import spire
+from modules.basemod_wrapper.cards import _enqueue_action
+
+SelectCardsInHandAction = spire.action("select_cards_in_hand")  # Unified facade lookup.【F:modules/basemod_wrapper/__init__.py†L134-L182】【F:modules/basemod_wrapper/__init__.py†L215-L224】
+
+def handle_selection(chosen):
+    for card in chosen:
+        card.upgrade()
+
+action = SelectCardsInHandAction(
+    1,                                # amount to pick
+    "upgrade",                        # text appended to the base "Select X card(s) to" banner
+    False,                            # anyNumber – force exact picks
+    True,                             # canPickZero – allow skipping
+    lambda c: c.type.name() == "SKILL",  # predicate (skills only)
+    handle_selection                  # callback invoked with a java.util.List<AbstractCard>
+)
+_enqueue_action(action)
+```
+
+### Tips
+
+* The callback runs once and receives the `selectedCards` list exactly as returned by the screen. Make sure to copy cards if you intend to queue additional actions that might reuse the list reference later.
+* Call `AbstractDungeon.player.hand.refreshHandLayout()` or rely on the action's built-in `finish()` to restore ordering – the helper already refreshes layout and reapplies powers when the action ends.【F:research/stslib_SelectCardsInHandAction.java†L95-L101】
+
+## ChooseFromDrawPile via `SelectCardsAction`
+
+`SelectCardsAction` wraps the base grid selector (`AbstractDungeon.gridSelectScreen`) and works with any `CardGroup`, making it ideal for draw pile selection.【F:research/stslib_SelectCardsAction.java†L1-L90】
+
+### Key behaviours
+
+* Accepts an `ArrayList<AbstractCard>` source (e.g. `AbstractDungeon.player.drawPile.group`) and clones it into an internal `CardGroup` to avoid double-render "jiggle" issues.【F:research/stslib_SelectCardsAction.java†L22-L52】
+* Applies an optional predicate before the screen opens so ineligible cards never appear.【F:research/stslib_SelectCardsAction.java†L42-L52】
+* Automatically short-circuits when the filtered group size is below or equal to the required amount (and `anyNumber` is false).【F:research/stslib_SelectCardsAction.java†L60-L76】
+* Opens the familiar grid screen with your custom prompt and respects `anyNumber`/`amount` constraints.【F:research/stslib_SelectCardsAction.java†L67-L74】
+
+### Python usage
+
+```python
+from modules.basemod_wrapper import spire
+from modules.basemod_wrapper.cards import _enqueue_action
+
+SelectCardsAction = spire.action("select_cards")  # Uses the same action lookup table as above.【F:modules/basemod_wrapper/__init__.py†L134-L182】【F:modules/basemod_wrapper/__init__.py†L215-L224】
+
+def move_to_hand(chosen):
+    for card in list(chosen):
+        AbstractDungeon.player.drawPile.removeCard(card)
+        AbstractDungeon.actionManager.addToBottom(
+            spire.cardcrawl.actions.common.MakeTempCardInHandAction(card)
+        )
+
+draw_pile = AbstractDungeon.player.drawPile.group
+
+action = SelectCardsAction(
+    draw_pile,
+    2,                                 # pick up to 2 cards
+    "move to your hand",              # bottom prompt string
+    True,                              # anyNumber – allow selecting fewer than 2
+    lambda c: not c.isCurse(),         # optional filter
+    move_to_hand                       # callback handles the results
+)
+_enqueue_action(action)
+```
+
+### Tips
+
+* Because the action returns the actual `selectedCards` list from the grid screen, always clear or copy it after use if you plan to mutate it later.
+* The helper automatically clears `gridSelectScreen.selectedCards` and refreshes the player's hand after completion, so the queue stays in a clean state.【F:research/stslib_SelectCardsAction.java†L76-L89】
+* For "select exactly N" behaviour, pass `anyNumber=False`; for optional picks (including zero) set it to `True`.
+
+## Integration advice
+
+* Both helpers are exposed via the global plugin manager (`PLUGIN_MANAGER.expose("spire", spire)`), so plugins can discover and call them without extra wiring.【F:modules/basemod_wrapper/__init__.py†L341-L371】
+* When embedding the flows into existing card actions, always queue your follow-up work inside the callback (or queue a new action from within) to maintain the game's asynchronous action pipeline.
+* If you need to interleave multiple selection flows in a single turn, guard against reusing the grid or hand screen while it's already open – the helper actions do this automatically by ticking until `selectedCards` is populated.

--- a/research/stslib_SelectCardsAction.java
+++ b/research/stslib_SelectCardsAction.java
@@ -1,0 +1,99 @@
+package com.evacipated.cardcrawl.mod.stslib.actions.common;
+
+import com.evacipated.cardcrawl.mod.stslib.patches.CenterGridCardSelectScreen;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class SelectCardsAction
+        extends AbstractGameAction {
+    private Consumer<List<AbstractCard>> callback;
+    private String text;
+    private boolean anyNumber;
+    private CardGroup selectGroup;
+
+    /**
+     * @param group         - ArrayList of cards to filter and select from.
+     *                      Example: AbstractDungeon.player.discardPile.group
+     * @param amount        - maximum number of cards allowed for selectoin
+     * @param textForSelect - text that will be displayed on the grid select screen at the bottom. It will show just this text with nothing else added by itself.
+     * @param anyNumber     - whether player has to select exact number of cards (amount) or any number up to, including 0.
+     *                      false for exact number.
+     * @param cardFilter    - Filters the cards in the group.
+     *                      Example: if you want to display only skills, it would be c -> c.type == CardType.SKILL
+     *                      If you don't need the filter, set it as c -> true
+     * @param callback      - What to do with cards selected. Accepts a list with cards selected. The list would only contain one element if it's "Select one card"
+     *                      Example: if you want to lose 1 hp and upgrade each card selected, it would look like
+     *                      list -> {
+     *                      addToBot(
+     *                      new LoseHPAction(player, player, list.size());
+     *                      list.forEach(c -> c.upgrade());
+     *                      )}
+     *                      <p>
+     *                      if there's no callback the action will not trigger simply because you told player to "select cards to do nothing with them"
+     *
+     */
+
+    public SelectCardsAction(ArrayList<AbstractCard> group, int amount, String textForSelect, boolean anyNumber, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this.amount = amount;
+        this.duration = this.startDuration = Settings.ACTION_DUR_XFAST;
+        text = textForSelect;
+        this.anyNumber = anyNumber;
+        this.callback = callback;
+        this.selectGroup = new CardGroup(CardGroup.CardGroupType.UNSPECIFIED);
+        this.selectGroup.group.addAll(group.stream().distinct().filter(cardFilter).collect(Collectors.toList()));
+        // It's distinct() because if i don't it may cause the infamous "jiggle" when you see a grid of cards with a same object in different locations.
+    }
+
+    public SelectCardsAction(ArrayList<AbstractCard> group, String textForSelect, boolean anyNumber, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this(group, 1, textForSelect, anyNumber, cardFilter, callback);
+    }
+
+    public SelectCardsAction(ArrayList<AbstractCard> group, String textForSelect, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this(group, 1, textForSelect, false, cardFilter, callback);
+    }
+
+    public SelectCardsAction(ArrayList<AbstractCard> group, String textForSelect, Consumer<List<AbstractCard>> callback) {
+        this(group, 1, textForSelect, false, c -> true, callback);
+    }
+
+    public SelectCardsAction(ArrayList<AbstractCard> group, int amount, String textForSelect, Consumer<List<AbstractCard>> callback) {
+        this(group, amount, textForSelect, false, c -> true, callback);
+    }
+
+    @Override
+    public void update() {
+        if (this.duration == this.startDuration) {
+            if ((selectGroup.size() == 0) || callback == null) {
+                isDone = true;
+                return;
+            }
+
+            if (selectGroup.size() <= amount && !anyNumber) {
+                callback.accept(selectGroup.group);
+                isDone = true;
+                return;
+            }
+
+            AbstractDungeon.gridSelectScreen.open(selectGroup, amount, anyNumber, text);
+            tickDuration();
+        }
+
+        if (AbstractDungeon.gridSelectScreen.selectedCards.size() != 0) {
+            callback.accept(AbstractDungeon.gridSelectScreen.selectedCards);
+            AbstractDungeon.gridSelectScreen.selectedCards.clear();
+            AbstractDungeon.player.hand.refreshHandLayout();
+            isDone = true;
+            return;
+        }
+        tickDuration();
+    }
+}

--- a/research/stslib_SelectCardsInHandAction.java
+++ b/research/stslib_SelectCardsInHandAction.java
@@ -1,0 +1,115 @@
+package com.evacipated.cardcrawl.mod.stslib.actions.common;
+
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class SelectCardsInHandAction extends AbstractGameAction {
+    private Predicate<AbstractCard> predicate;
+    private Consumer<List<AbstractCard>> callback;
+    private String text;
+    private boolean anyNumber, canPickZero;
+    private ArrayList<AbstractCard> hand;
+    private ArrayList<AbstractCard> tempHand = new ArrayList<>();
+
+    /**
+    * @param amount - max number of cards player can select
+    * @param textForSelect - text that will be displayed at the top of the screen. It will be automatically attached to base game "Select X card/s to " text
+    * @param anyNumber - whether player has to select exact number of cards or any number up to.
+    * false for exact number
+    * @param canPickZero - whether player can skip selection by picking zero cards.
+    * @param cardFilter - filter that will be applied to cards in hand.
+    * Example: if you want to display only skills, it would be c -> c.type == CardType.SKILL
+    * If you don't need the filter, set it as c -> true
+    * @param callback - What to do with cards selected.
+    * Example: if you want to lose 1 hp and upgrade each card selected, it would look like
+    * list -> {
+    * addToBot(
+    * new LoseHPAction(player, player, list.size());
+    * list.forEach(c -> c.upgrade());
+    * )}
+    * if there's no callback the action will not trigger simply because you told player to "select cards to do nothing with them"
+    **/
+
+    public SelectCardsInHandAction(int amount, String textForSelect, boolean anyNumber, boolean canPickZero, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this.amount = amount;
+        this.duration = this.startDuration = Settings.ACTION_DUR_XFAST;
+        text = textForSelect;
+        this.anyNumber = anyNumber;
+        this.canPickZero = canPickZero;
+        this.predicate = cardFilter;
+        this.callback = callback;
+        this.hand = AbstractDungeon.player.hand.group;
+    }
+
+    public SelectCardsInHandAction(int amount, String textForSelect, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this(amount, textForSelect, false, false, cardFilter, callback);
+    }
+
+    public SelectCardsInHandAction(int amount, String textForSelect, Consumer<List<AbstractCard>> callback) {
+        this(amount, textForSelect, false, false, (c -> true), callback);
+    }
+
+    public SelectCardsInHandAction(String textForSelect, Predicate<AbstractCard> cardFilter, Consumer<List<AbstractCard>> callback) {
+        this(1, textForSelect, false, false, cardFilter, callback);
+    }
+
+    public SelectCardsInHandAction(String textForSelect, Consumer<List<AbstractCard>> callback) {
+        this(1, textForSelect, false, false, (c -> true), callback);
+    }
+
+    @Override
+    public void update() {
+        if (this.duration == this.startDuration) {
+
+            if (callback == null) {
+                isDone = true;
+                return;
+            }
+
+            hand.removeIf(c -> !predicate.test(c) && tempHand.add(c));
+
+            if ((hand.size() == 0)) {
+                finish();
+                return;
+            }
+
+            if (hand.size() <= amount && !anyNumber && !canPickZero) {
+                ArrayList<AbstractCard> spoof = new ArrayList<>(hand); //basically recreating the process that the screen does to make sure results are the same.
+                hand.clear();
+                callback.accept(spoof);
+                hand.addAll(spoof);
+                finish();
+                return;
+            }
+
+            AbstractDungeon.handCardSelectScreen.open(text, amount, anyNumber, canPickZero);
+            tickDuration();
+            return;
+        }
+
+        if (!AbstractDungeon.handCardSelectScreen.wereCardsRetrieved) {
+            callback.accept(AbstractDungeon.handCardSelectScreen.selectedCards.group);
+            hand.addAll(AbstractDungeon.handCardSelectScreen.selectedCards.group);
+            AbstractDungeon.handCardSelectScreen.wereCardsRetrieved = true;
+            AbstractDungeon.handCardSelectScreen.selectedCards.group.clear();
+            finish();
+            return;
+        }
+        tickDuration();
+    }
+
+    private void finish() {
+        hand.addAll(tempHand);
+        AbstractDungeon.player.hand.refreshHandLayout();
+        AbstractDungeon.player.hand.applyPowers();
+        isDone = true;
+    }
+}


### PR DESCRIPTION
## Summary
- add research note explaining how to use StSLib selection actions for hand and draw pile flows
- vendor StSLib SelectCardsAction and SelectCardsInHandAction sources into the research archive for reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc64ee65483278dc1d816501312a5