### PR TITLE
Add fixture toggle and expand card blueprint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,22 @@ from tests.stubs import (
 )
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--use-real-dependencies",
+        action="store_true",
+        default=False,
+        help="Run tests against the real BaseMod runtime without monkeypatched stubs.",
+    )
+
+
+@pytest.fixture()
+def use_real_dependencies(request: pytest.FixtureRequest) -> bool:
+    """Return True when the caller requested real runtime dependencies."""
+
+    return bool(request.config.getoption("--use-real-dependencies"))
+
+
 @pytest.fixture()
 def stubbed_runtime(monkeypatch):
     action_manager = StubActionManager()


### PR DESCRIPTION
## Summary
- add a pytest command-line option and fixture to toggle real dependency usage in tests
- extend card blueprint tests with additional coverage for inner image setup and exhaustive-use validation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbca6878bc83278ff5f2b86211eb4c