### PR TITLE
Add Character and Deck scaffolding for mod creation

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -80,3 +80,12 @@ Usage: expose optional callbacks on the base class (``on_draw``, ``on_intent``)
 that the scheduler wires into BaseMod subscribers, and surface the registration
 points on ``PLUGIN_MANAGER`` so third-party extensions can augment the event
 matrix without monkeypatching the core implementation.
+
+## Character builder scaffolding
+
+Teach the high-level `Character` helper to generate self-contained runtime
+packages so that mods assembled through the declarative decks API can bundle a
+ready-to-run `project.py`. Usage: extend `Character.createMod` with an optional
+`generate_python_package` flag that writes a minimal package embedding the
+registered decks and characters, ensuring teams without an existing Python code
+base can still rely on the automated bundler.

--- a/modules/basemod_wrapper/project.py
+++ b/modules/basemod_wrapper/project.py
@@ -119,6 +119,9 @@ class CharacterBlueprint:
     banner_texture: Optional[str] = None
     select_button_texture: Optional[str] = None
     energy_image: Optional[str] = None
+    skeleton_atlas: Optional[str] = None
+    skeleton_json: Optional[str] = None
+    skeleton_scale: float = 1.0
 
     def build_player_class(self, color_enum: object, player_enum: object, color_definition: ColorDefinition) -> Type:
         import jpype
@@ -148,6 +151,15 @@ class CharacterBlueprint:
                     EnergyManager(self.blueprint.energy_per_turn),
                     self.blueprint.energy_image,
                 )
+                atlas = self.blueprint.skeleton_atlas
+                json = self.blueprint.skeleton_json
+                scale = float(self.blueprint.skeleton_scale)
+                if atlas and json:
+                    self.loadAnimation(atlas, json, scale)
+                elif atlas or json:
+                    raise BaseModBootstrapError(
+                        "Character blueprints require both skeleton atlas and json paths when supplying animation assets."
+                    )
 
             def getLoadout(self):
                 Loadout = CustomPlayer.Loadout

--- a/modules/modbuilder/__init__.py
+++ b/modules/modbuilder/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .deck import Deck
+from .character import Character, CharacterColorConfig, CharacterImageConfig, CharacterStartConfig
+from plugins import PLUGIN_MANAGER
+
+PLUGIN_MANAGER.expose("Deck", Deck)
+PLUGIN_MANAGER.expose("Character", Character)
+PLUGIN_MANAGER.expose("CharacterStartConfig", CharacterStartConfig)
+PLUGIN_MANAGER.expose("CharacterImageConfig", CharacterImageConfig)
+PLUGIN_MANAGER.expose("CharacterColorConfig", CharacterColorConfig)
+PLUGIN_MANAGER.expose_module("modules.modbuilder")
+
+__all__ = [
+    "Deck",
+    "Character",
+    "CharacterStartConfig",
+    "CharacterImageConfig",
+    "CharacterColorConfig",
+]

--- a/modules/modbuilder/character.py
+++ b/modules/modbuilder/character.py
@@ -1,0 +1,657 @@
+from __future__ import annotations
+
+import json
+import math
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+
+from modules.basemod_wrapper.card_assets import ensure_pillow
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.loader import BaseModBootstrapError, ensure_dependency_classpath
+from modules.basemod_wrapper.project import (
+    BundleOptions,
+    CharacterAssets,
+    CharacterBlueprint,
+    ModProject,
+    create_project,
+)
+
+from .deck import Deck
+
+
+ColorTuple = Tuple[float, float, float, float]
+RARITY_TARGETS: Mapping[str, float] = {"COMMON": 0.60, "UNCOMMON": 0.37, "RARE": 0.03}
+
+
+@dataclass(slots=True)
+class CharacterStartConfig:
+    hp: int = 72
+    max_hp: Optional[int] = None
+    gold: int = 99
+    deck: Optional[Union[Type[Deck], Deck]] = None
+    relics: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class CharacterImageConfig:
+    shoulder1: Optional[str] = None
+    shoulder2: Optional[str] = None
+    corpse: Optional[str] = None
+    staticspineanimation: Optional[str] = None
+    staticspineatlas: Optional[str] = None
+    staticspinejson: Optional[str] = None
+    energy_orb: Optional[str] = None
+    banner: Optional[str] = None
+    select: Optional[str] = None
+
+
+@dataclass(slots=True)
+class CharacterColorConfig:
+    identifier: Optional[str] = None
+    card_color: Optional[ColorTuple] = None
+    trail_color: Optional[ColorTuple] = None
+    slash_color: Optional[ColorTuple] = None
+    attack_bg: Optional[str] = None
+    skill_bg: Optional[str] = None
+    power_bg: Optional[str] = None
+    orb: Optional[str] = None
+    attack_bg_small: Optional[str] = None
+    skill_bg_small: Optional[str] = None
+    power_bg_small: Optional[str] = None
+    orb_small: Optional[str] = None
+
+
+def _slugify(value: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "_" for ch in value.strip())
+    while "__" in cleaned:
+        cleaned = cleaned.replace("__", "_")
+    return cleaned.strip("_") or "mod"
+
+
+class Character:
+    """High level helper that wires decks and assets into a mod project."""
+
+    def __init__(self) -> None:
+        name = self.__class__.__name__
+        self.name: str = name
+        self.mod_id: str = _slugify(name)
+        self.author: str = "Unknown"
+        self.description: str = ""
+        self.version: str = "0.1.0"
+        self.handSize: int = 5
+        self.energyPerTurn: int = 3
+        self.orbSlots: int = 0
+        self.maxhp: int = 72
+        self.loadout_description: str = ""
+        self.banner_image: Optional[str] = None
+        self.select_button_image: Optional[str] = None
+        self.energy_image: Optional[str] = None
+        self.campfire_x: float = 0.0
+        self.campfire_y: float = 0.0
+        self.loadout_x: float = 220.0
+        self.loadout_y: float = 300.0
+
+        self.start = CharacterStartConfig()
+        self.image = CharacterImageConfig()
+        self.color = CharacterColorConfig(identifier=f"{self.mod_id.upper()}_COLOR")
+
+        self.unlockableDeck: Optional[Union[Type[Deck], Deck]] = None
+        self.assets_root: Optional[Path] = None
+        self.python_root: Optional[Path] = None
+        self.bundle_dependencies: Sequence[str] = ("basemod", "stslib")
+        self.additional_classpath: Sequence[Path] = ()
+        self.desktop_jar: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @classmethod
+    def createMod(
+        cls,
+        destination: Union[str, Path],
+        *,
+        assets_root: Optional[Union[str, Path]] = None,
+        python_source: Optional[Union[str, Path]] = None,
+        bundle: bool = True,
+        dependencies: Optional[Sequence[str]] = None,
+        additional_classpath: Optional[Sequence[Path]] = None,
+        java_classpath: Optional[Sequence[Path]] = None,
+        register_cards: bool = True,
+    ) -> Path:
+        character = cls()
+        assets_root_path = cls._resolve_assets_root(character, assets_root)
+        python_source_path = cls._resolve_python_source(cls, character, python_source)
+
+        start_deck_cls = cls._coerce_deck(character.start.deck, "start")
+        unlockable_deck_cls = cls._coerce_deck(character.unlockableDeck, "unlockable")
+
+        if start_deck_cls is None:
+            raise BaseModBootstrapError("Characters must declare a start deck before bundling.")
+        start_cards = list(start_deck_cls.cards())
+        unlockable_cards = list(unlockable_deck_cls.cards()) if unlockable_deck_cls else []
+        all_cards = start_cards + unlockable_cards
+        unique_cards = cls._compute_unique_cards(start_cards, unlockable_cards)
+
+        errors: List[str] = []
+        count_error = cls._validate_card_totals(all_cards)
+        if count_error:
+            errors.append(count_error)
+        ratio_error = cls._validate_rarity_ratio(all_cards)
+        if ratio_error:
+            errors.append(ratio_error)
+        asset_error = cls._validate_assets(
+            character,
+            assets_root_path,
+            unique_cards,
+        )
+        if asset_error:
+            errors.append(asset_error)
+        if errors:
+            raise BaseModBootstrapError(" ".join(errors))
+
+        cls._prepare_static_spine(character, assets_root_path)
+
+        if bundle and not register_cards:
+            raise BaseModBootstrapError("Cards must be registered when bundling the mod.")
+
+        project: Optional[ModProject]
+        project = None
+        if register_cards or bundle:
+            project = cls._build_project(character)
+            cls._apply_color(character, project)
+            for blueprint in unique_cards.values():
+                project.add_simple_card(blueprint)
+
+            blueprint = cls._build_character_blueprint(character, start_cards)
+            project.add_character(blueprint)
+
+        output_root = Path(destination).resolve()
+        output_root.mkdir(parents=True, exist_ok=True)
+
+        bundle_dependencies = dependencies or character.bundle_dependencies
+        extra_classpath = list(character.additional_classpath)
+        if additional_classpath:
+            extra_classpath.extend(additional_classpath)
+
+        if not bundle:
+            mod_name = character.name.replace(" ", "")
+            return output_root / mod_name
+
+        if project is None:
+            raise BaseModBootstrapError("Project setup was skipped; unable to bundle.")
+        options = cls._build_bundle_options(
+            character,
+            assets_root_path,
+            python_source_path,
+            output_root,
+            bundle_dependencies,
+            java_classpath,
+            extra_classpath,
+        )
+        return project.compile_and_bundle(options)
+
+    # ------------------------------------------------------------------
+    # Helper construction
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _coerce_deck(deck: Optional[Union[Type[Deck], Deck]], label: str) -> Optional[Type[Deck]]:
+        if deck is None:
+            return None
+        if isinstance(deck, Deck):
+            return type(deck)
+        if isinstance(deck, type) and issubclass(deck, Deck):
+            return deck
+        raise BaseModBootstrapError(f"{label.capitalize()} deck must inherit from Deck.")
+
+    @staticmethod
+    def _compute_unique_cards(
+        start_cards: Sequence[SimpleCardBlueprint],
+        unlockable_cards: Sequence[SimpleCardBlueprint],
+    ) -> Dict[str, SimpleCardBlueprint]:
+        mapping: Dict[str, SimpleCardBlueprint] = {}
+        for blueprint in list(start_cards) + list(unlockable_cards):
+            mapping.setdefault(blueprint.identifier, blueprint)
+        return mapping
+
+    @staticmethod
+    def _validate_card_totals(cards: Sequence[SimpleCardBlueprint]) -> Optional[str]:
+        total = len(cards)
+        if total >= 75:
+            return None
+        missing = 75 - total
+        return (
+            f"This deck has {total} cards. We need {missing} more cards to be able to compile the mod."
+        )
+
+    @classmethod
+    def _validate_rarity_ratio(cls, cards: Sequence[SimpleCardBlueprint]) -> Optional[str]:
+        if not cards:
+            return None
+        actual_counts: Dict[str, int] = {key: 0 for key in RARITY_TARGETS}
+        for blueprint in cards:
+            rarity = blueprint.rarity.upper()
+            if rarity == "BASIC":
+                rarity = "COMMON"
+            if rarity in actual_counts:
+                actual_counts[rarity] += 1
+        total = len(cards)
+        targets = cls._compute_target_counts(total)
+        adjustments: List[str] = []
+        for rarity, required in targets.items():
+            current = actual_counts.get(rarity, 0)
+            diff = required - current
+            if diff > 0:
+                adjustments.append(f"add {diff} {rarity.lower()}")
+            elif diff < 0:
+                adjustments.append(f"remove {abs(diff)} {rarity.lower()}")
+        if not adjustments:
+            return None
+        joined = ", ".join(adjustments)
+        return (
+            "Card Rarity Proportions Incorrect. "
+            "Adjust the deck by applying these changes: "
+            f"{joined}."
+        )
+
+    @staticmethod
+    def _compute_target_counts(total: int) -> Dict[str, int]:
+        raw = {rarity: total * ratio for rarity, ratio in RARITY_TARGETS.items()}
+        floors = {rarity: int(math.floor(value)) for rarity, value in raw.items()}
+        allocated = sum(floors.values())
+        remainder = total - allocated
+        ordered = sorted(RARITY_TARGETS, key=lambda key: (raw[key] - floors[key]), reverse=True)
+        for rarity in ordered:
+            if remainder <= 0:
+                break
+            floors[rarity] += 1
+            remainder -= 1
+        return floors
+
+    @classmethod
+    def _validate_assets(
+        cls,
+        character: "Character",
+        assets_root: Path,
+        cards: Mapping[str, SimpleCardBlueprint],
+    ) -> Optional[str]:
+        mod_id = character.mod_id
+        missing_cards: Dict[str, List[str]] = {}
+        for identifier, blueprint in cards.items():
+            issues: List[str] = []
+            if blueprint.inner_image_source:
+                inner_path = Path(blueprint.inner_image_source)
+                if not inner_path.exists():
+                    issues.append(f"inner image '{inner_path}' is missing")
+            image_path = blueprint.image or f"{mod_id}/images/cards/{blueprint.identifier}.png"
+            resolved = cls._resource_path(image_path, assets_root, mod_id)
+            if not resolved.exists():
+                issues.append(f"card image '{resolved}' is missing")
+            if issues:
+                missing_cards[identifier] = issues
+        asset_issues: List[str] = []
+        if character.image.shoulder1:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "shoulder image",
+                    character.image.shoulder1,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.image.shoulder2:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "shoulder2 image",
+                    character.image.shoulder2,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.image.corpse:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "corpse image",
+                    character.image.corpse,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.image.energy_orb:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "energy orb",
+                    character.image.energy_orb,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.banner_image:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "banner",
+                    character.banner_image,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.select_button_image:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "select button",
+                    character.select_button_image,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        if character.energy_image:
+            asset_issues.extend(
+                cls._missing_asset_messages(
+                    "energy image",
+                    character.energy_image,
+                    assets_root,
+                    mod_id,
+                )
+            )
+        for attr in (
+            "attack_bg",
+            "skill_bg",
+            "power_bg",
+            "orb",
+            "attack_bg_small",
+            "skill_bg_small",
+            "power_bg_small",
+            "orb_small",
+        ):
+            value = getattr(character.color, attr)
+            if value:
+                asset_issues.extend(
+                    cls._missing_asset_messages(f"color {attr}", value, assets_root, mod_id)
+                )
+        if character.image.staticspineanimation:
+            static_path = cls._resource_path(
+                character.image.staticspineanimation,
+                assets_root,
+                mod_id,
+            )
+            if not static_path.exists():
+                asset_issues.append(f"static spine image '{static_path}' is missing")
+        if not missing_cards and not asset_issues:
+            return None
+        message_parts: List[str] = []
+        if missing_cards:
+            details = []
+            for identifier, issues in sorted(missing_cards.items()):
+                blueprint = cards[identifier]
+                issues_str = "; ".join(issues)
+                details.append(f"- {identifier}: {issues_str} | blueprint={blueprint!r}")
+            message_parts.append("Missing assets for cards:\n" + "\n".join(details))
+        if asset_issues:
+            message_parts.append("Missing character assets: " + "; ".join(sorted(asset_issues)))
+        return " ".join(message_parts)
+
+    @staticmethod
+    def _missing_asset_messages(label: str, resource: str, assets_root: Path, mod_id: str) -> List[str]:
+        resolved = Character._resource_path(resource, assets_root, mod_id)
+        if resolved.exists():
+            return []
+        return [f"{label} '{resolved}' is missing"]
+
+    @staticmethod
+    def _resource_path(resource: str, assets_root: Path, mod_id: str) -> Path:
+        candidate = Path(resource)
+        if candidate.is_absolute():
+            return candidate
+        cleaned = resource.replace("\\", "/").strip("/")
+        prefix = f"{mod_id}/"
+        if cleaned.startswith(prefix):
+            cleaned = cleaned[len(prefix) :]
+        resolved = (assets_root / cleaned).resolve()
+        try:
+            assets_root_resolved = assets_root.resolve()
+            resolved.relative_to(assets_root_resolved)
+        except Exception:
+            pass
+        return resolved
+
+    @classmethod
+    def _prepare_static_spine(cls, character: "Character", assets_root: Path) -> None:
+        if not character.image.staticspineanimation:
+            return
+        mod_id = character.mod_id
+        image_path = cls._resource_path(
+            character.image.staticspineanimation,
+            assets_root,
+            mod_id,
+        )
+        if not image_path.exists():
+            return
+        Image = ensure_pillow()
+        with Image.open(image_path) as handle:  # type: ignore[attr-defined]
+            width, height = handle.size
+        atlas_path = image_path.with_suffix(".atlas")
+        json_path = image_path.with_suffix(".json")
+        region_name = image_path.stem
+        atlas_content = (
+            f"{image_path.name}\n"
+            f"size: {width}, {height}\n"
+            "format: RGBA8888\n"
+            "filter: Linear,Linear\n"
+            "repeat: none\n"
+            f"{region_name}\n"
+            "  rotate: false\n"
+            "  xy: 0, 0\n"
+            f"  size: {width}, {height}\n"
+            f"  orig: {width}, {height}\n"
+            "  offset: 0, 0\n"
+            "  index: -1\n"
+        )
+        atlas_path.write_text(atlas_content, encoding="utf8")
+        skeleton = {
+            "skeleton": {
+                "hash": "",
+                "spine": "3.7.94",
+                "width": width,
+                "height": height,
+                "images": "",
+            },
+            "bones": [{"name": "root"}],
+            "slots": [
+                {"name": "main", "bone": "root", "attachment": region_name},
+            ],
+            "skins": {
+                "default": {
+                    "main": {
+                        region_name: {
+                            "name": region_name,
+                            "path": image_path.name,
+                            "x": 0,
+                            "y": 0,
+                            "width": width,
+                            "height": height,
+                        }
+                    }
+                }
+            },
+            "animations": {"idle": {}},
+        }
+        json_path.write_text(json.dumps(skeleton, indent=2), encoding="utf8")
+        relative_base = character.image.staticspineanimation.replace("\\", "/").strip("/")
+        prefix = f"{mod_id}/"
+        if relative_base.startswith(prefix):
+            relative_base = relative_base[len(prefix) :]
+        base_no_ext = Path(relative_base).with_suffix("")
+        atlas_resource = f"{mod_id}/{base_no_ext.with_suffix('.atlas')}".replace("\\", "/")
+        json_resource = f"{mod_id}/{base_no_ext.with_suffix('.json')}".replace("\\", "/")
+        character.image.staticspineatlas = atlas_resource
+        character.image.staticspinejson = json_resource
+
+    @classmethod
+    def _build_project(cls, character: "Character") -> ModProject:
+        project = create_project(
+            character.mod_id,
+            character.name,
+            character.author,
+            character.description,
+            version=character.version,
+        )
+        return project
+
+    @classmethod
+    def _apply_color(cls, character: "Character", project: ModProject) -> None:
+        color = character.color
+        required = (
+            color.identifier,
+            color.card_color,
+            color.trail_color,
+            color.slash_color,
+            color.attack_bg,
+            color.skill_bg,
+            color.power_bg,
+            color.orb,
+            color.attack_bg_small,
+            color.skill_bg_small,
+            color.power_bg_small,
+            color.orb_small,
+        )
+        if any(value is None for value in required):
+            raise BaseModBootstrapError("Character colour configuration is incomplete.")
+        project.define_color(
+            color.identifier,  # type: ignore[arg-type]
+            card_color=color.card_color,  # type: ignore[arg-type]
+            trail_color=color.trail_color,  # type: ignore[arg-type]
+            slash_color=color.slash_color,  # type: ignore[arg-type]
+            attack_bg=color.attack_bg,  # type: ignore[arg-type]
+            skill_bg=color.skill_bg,  # type: ignore[arg-type]
+            power_bg=color.power_bg,  # type: ignore[arg-type]
+            orb=color.orb,  # type: ignore[arg-type]
+            attack_bg_small=color.attack_bg_small,  # type: ignore[arg-type]
+            skill_bg_small=color.skill_bg_small,  # type: ignore[arg-type]
+            power_bg_small=color.power_bg_small,  # type: ignore[arg-type]
+            orb_small=color.orb_small,  # type: ignore[arg-type]
+        )
+
+    @classmethod
+    def _build_character_blueprint(
+        cls,
+        character: "Character",
+        start_cards: Sequence[SimpleCardBlueprint],
+    ) -> CharacterBlueprint:
+        assets = CharacterAssets(
+            shoulder_image=character.image.shoulder1 or "",
+            shoulder2_image=character.image.shoulder2 or "",
+            corpse_image=character.image.corpse or "",
+            energy_orb_small=character.image.energy_orb,
+        )
+        blueprint = CharacterBlueprint(
+            identifier=f"{character.mod_id}_character",
+            character_name=character.name,
+            description=character.description or character.name,
+            assets=assets,
+            starting_deck=[card.identifier for card in start_cards],
+            starting_relics=list(character.start.relics),
+            loadout_description=character.loadout_description or character.description,
+            energy_per_turn=character.energyPerTurn,
+            card_draw=character.handSize,
+            max_hp=character.start.max_hp if character.start.max_hp is not None else character.maxhp,
+            starting_hp=character.start.hp,
+            starting_gold=character.start.gold,
+            orb_slots=character.orbSlots,
+            campfire_x=character.campfire_x,
+            campfire_y=character.campfire_y,
+            loadout_x=character.loadout_x,
+            loadout_y=character.loadout_y,
+            banner_texture=character.banner_image,
+            select_button_texture=character.select_button_image,
+            energy_image=character.energy_image,
+            skeleton_atlas=character.image.staticspineatlas,
+            skeleton_json=character.image.staticspinejson,
+            skeleton_scale=1.0,
+        )
+        return blueprint
+
+    @classmethod
+    def _build_bundle_options(
+        cls,
+        character: "Character",
+        assets_root: Path,
+        python_root: Path,
+        output_root: Path,
+        dependencies: Sequence[str],
+        java_classpath: Optional[Sequence[Path]],
+        extra_classpath: Sequence[Path],
+    ) -> BundleOptions:
+        if java_classpath is not None:
+            classpath = list(java_classpath)
+        else:
+            jars = ensure_dependency_classpath()
+            classpath = [jars["basemod"], jars["modthespire"]]
+            if "stslib" in dependencies and "stslib" in jars:
+                classpath.append(jars["stslib"])
+        if character.desktop_jar is not None:
+            classpath.append(Path(character.desktop_jar))
+        classpath.extend(extra_classpath)
+        unique_classpath = list(dict.fromkeys(Path(entry) for entry in classpath))
+        options = BundleOptions(
+            java_classpath=tuple(unique_classpath),
+            python_source=python_root,
+            assets_source=assets_root,
+            output_directory=output_root,
+            version=character.version,
+            sts_version="2020-12-01",
+            mts_version="3.30.1",
+            dependencies=dependencies,
+        )
+        return options
+
+    # ------------------------------------------------------------------
+    # Path resolution helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_assets_root(
+        character: "Character",
+        assets_root: Optional[Union[str, Path]],
+    ) -> Path:
+        path = Path(assets_root) if assets_root is not None else character.assets_root
+        if path is None:
+            raise BaseModBootstrapError("Assets root directory is required for createMod().")
+        resolved = Path(path).resolve()
+        if not resolved.exists():
+            raise BaseModBootstrapError(f"Assets directory '{resolved}' does not exist.")
+        return resolved
+
+    @staticmethod
+    def _resolve_python_source(
+        cls: Type["Character"],
+        character: "Character",
+        python_source: Optional[Union[str, Path]],
+    ) -> Path:
+        if python_source is not None:
+            resolved = Path(python_source).resolve()
+            if not resolved.exists():
+                raise BaseModBootstrapError(f"Python source directory '{resolved}' does not exist.")
+            return resolved
+        if character.python_root is not None:
+            resolved = Path(character.python_root).resolve()
+            if not resolved.exists():
+                raise BaseModBootstrapError(f"Python source directory '{resolved}' does not exist.")
+            return resolved
+        module = sys.modules.get(cls.__module__)
+        if module is None or not hasattr(module, "__file__"):
+            raise BaseModBootstrapError("Unable to resolve python source automatically.")
+        module_file_attr = getattr(module, "__file__", None)
+        if module_file_attr is None:
+            raise BaseModBootstrapError("Unable to resolve python source automatically.")
+        module_file = Path(module_file_attr).resolve()
+        package = getattr(module, "__package__", "") or module.__name__
+        depth = len(package.split(".")) - 1
+        directory = module_file.parent
+        for _ in range(depth):
+            directory = directory.parent
+        if not directory.exists():
+            raise BaseModBootstrapError("Derived python source directory does not exist.")
+        return directory
+
+
+__all__ = ["Character", "CharacterStartConfig", "CharacterImageConfig", "CharacterColorConfig"]

--- a/modules/modbuilder/deck.py
+++ b/modules/modbuilder/deck.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+
+
+class DeckMeta(type):
+    """Metaclass that keeps track of cards registered on subclasses."""
+
+    def __new__(mcls, name: str, bases: Tuple[type, ...], namespace: Dict[str, object]):
+        cls = super().__new__(mcls, name, bases, namespace)
+        cls._card_sequence: List[SimpleCardBlueprint] = []  # type: ignore[attr-defined]
+        return cls
+
+    def __iter__(cls) -> Iterator[SimpleCardBlueprint]:  # pragma: no cover - trivial delegation
+        return iter(cls._card_sequence)
+
+    def __len__(cls) -> int:  # pragma: no cover - trivial delegation
+        return len(cls._card_sequence)
+
+
+class Deck(metaclass=DeckMeta):
+    """Base class representing an ordered collection of card blueprints."""
+
+    display_name: str
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.display_name = getattr(cls, "display_name", cls.__name__)
+
+    # ------------------------------------------------------------------
+    # Card management helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def addCard(cls, blueprint: SimpleCardBlueprint) -> SimpleCardBlueprint:
+        """Register ``blueprint`` with the deck and return it."""
+
+        if not isinstance(blueprint, SimpleCardBlueprint):
+            raise TypeError("addCard expects a SimpleCardBlueprint instance.")
+        cls._card_sequence.append(blueprint)
+        return blueprint
+
+    @classmethod
+    def add_card(cls, blueprint: SimpleCardBlueprint) -> SimpleCardBlueprint:
+        """Alias mirroring the camelCase API used by authoring scripts."""
+
+        return cls.addCard(blueprint)
+
+    @classmethod
+    def extend(cls, blueprints: Iterable[SimpleCardBlueprint]) -> None:
+        """Append multiple ``blueprints`` in the given order."""
+
+        for blueprint in blueprints:
+            cls.addCard(blueprint)
+
+    @classmethod
+    def cards(cls) -> Tuple[SimpleCardBlueprint, ...]:
+        """Return an immutable snapshot of all card blueprints."""
+
+        return tuple(cls._card_sequence)
+
+    @classmethod
+    def unique_cards(cls) -> Dict[str, SimpleCardBlueprint]:
+        """Return a mapping of card identifiers to their first blueprint."""
+
+        mapping: Dict[str, SimpleCardBlueprint] = {}
+        for blueprint in cls._card_sequence:
+            mapping.setdefault(blueprint.identifier, blueprint)
+        return mapping
+
+    @classmethod
+    def rarity_counts(cls) -> Dict[str, int]:
+        """Return the rarity histogram for the current deck."""
+
+        counts = Counter(card.rarity for card in cls._card_sequence)
+        return dict(counts)
+
+    @classmethod
+    def card_identifiers(cls) -> List[str]:
+        """Return card identifiers preserving deck order."""
+
+        return [blueprint.identifier for blueprint in cls._card_sequence]
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove all card registrations from the deck."""
+
+        cls._card_sequence.clear()
+
+    @classmethod
+    def __iter__(cls) -> Iterator[SimpleCardBlueprint]:  # pragma: no cover - trivial delegation
+        return iter(cls._card_sequence)
+
+
+__all__ = ["Deck"]

--- a/research/static_spine_notes.md
+++ b/research/static_spine_notes.md
@@ -1,0 +1,10 @@
+# Static spine animation notes
+
+Source: [BaseMod Wiki – Custom Character Animations](https://github.com/daviscook477/BaseMod/wiki/Custom-Character-Animations)
+
+* Slay the Spire ships with a Spine runtime (3.7.x). Characters normally load an atlas + skeleton JSON pair via `loadAnimation`.
+* Mods without skeletal animations can fake the setup by generating a trivial atlas that declares a single region covering the PNG pose.
+* The matching skeleton JSON only needs one bone (`root`), one slot (`main`) and a default skin with the region attachment named after the PNG.
+* All coordinates in the attachment can be zero; the runtime simply renders the region at the origin for the idle animation.
+* The atlas header must echo the PNG dimensions, use `format: RGBA8888`, `filter: Linear,Linear` and `repeat: none` to match vanilla assets.
+* Providing an empty `idle` animation block is sufficient—the character remains static but passes BaseMod’s validation.

--- a/tests/test_modbuilder.py
+++ b/tests/test_modbuilder.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.modbuilder import Character, CharacterColorConfig, CharacterImageConfig, CharacterStartConfig, Deck
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.loader import BaseModBootstrapError
+from modules.basemod_wrapper.card_assets import ensure_pillow
+
+
+def _make_blueprint(identifier: str, rarity: str = "common", image_stub: str | None = None) -> SimpleCardBlueprint:
+    image_path = image_stub or f"buddy/images/cards/{identifier}.png"
+    return SimpleCardBlueprint(
+        identifier=identifier,
+        title=identifier,
+        description="Deal {damage} damage.",
+        cost=1,
+        card_type="attack",
+        target="enemy",
+        rarity=rarity,
+        value=7,
+        image=image_path,
+    )
+
+
+def _write_placeholder(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("asset", encoding="utf8")
+
+
+class _BaseTestCharacter(Character):
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Buddy"
+        self.mod_id = "buddy"
+        self.description = "Testing"
+        self.color = CharacterColorConfig(
+            identifier="BUDDY_BLUE",
+            card_color=(0.2, 0.4, 0.8, 1.0),
+            trail_color=(0.2, 0.3, 0.7, 1.0),
+            slash_color=(0.3, 0.5, 0.9, 1.0),
+            attack_bg="buddy/images/cards/attack.png",
+            skill_bg="buddy/images/cards/skill.png",
+            power_bg="buddy/images/cards/power.png",
+            orb="buddy/images/cards/orb.png",
+            attack_bg_small="buddy/images/cards/attack_small.png",
+            skill_bg_small="buddy/images/cards/skill_small.png",
+            power_bg_small="buddy/images/cards/power_small.png",
+            orb_small="buddy/images/cards/orb_small.png",
+        )
+        self.image = CharacterImageConfig(
+            shoulder1="buddy/images/character/shoulder1.png",
+            shoulder2="buddy/images/character/shoulder2.png",
+            corpse="buddy/images/character/corpse.png",
+        )
+        self.start = CharacterStartConfig()
+
+
+def _prepare_assets(root: Path, *, include_cards: dict[str, bool], include_static: bool = False) -> None:
+    for name, present in include_cards.items():
+        target = root / "images" / "cards" / name
+        if present:
+            _write_placeholder(target)
+    for name in [
+        "attack.png",
+        "skill.png",
+        "power.png",
+        "orb.png",
+        "attack_small.png",
+        "skill_small.png",
+        "power_small.png",
+        "orb_small.png",
+    ]:
+        _write_placeholder(root / "images" / "cards" / name)
+    for name in ["shoulder1.png", "shoulder2.png", "corpse.png"]:
+        _write_placeholder(root / "images" / "character" / name)
+    if include_static:
+        Image = ensure_pillow()
+        pose = root / "images" / "character" / "pose.png"
+        pose.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGBA", (64, 64), (255, 255, 255, 255)).save(pose)
+
+
+def _prepare_python_source(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "__init__.py").write_text("\n", encoding="utf8")
+
+
+def test_deck_collects_cards(use_real_dependencies: bool) -> None:
+    class StarterDeck(Deck):
+        pass
+
+    first = _make_blueprint("Strike")
+    second = _make_blueprint("Defend", rarity="uncommon")
+
+    StarterDeck.addCard(first)
+    StarterDeck.addCard(second)
+    StarterDeck.addCard(first)
+
+    cards = StarterDeck.cards()
+    assert len(cards) == 3
+    assert cards[0] is first
+    assert cards[1] is second
+    assert cards[2] is first
+
+
+def test_character_reports_missing_assets(tmp_path: Path, use_real_dependencies: bool) -> None:
+    class StarterDeck(Deck):
+        pass
+
+    StarterDeck.addCard(_make_blueprint("Strike"))
+
+    class DummyCharacter(_BaseTestCharacter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.start.deck = StarterDeck
+
+    assets_root = tmp_path / "assets" / "buddy"
+    _prepare_assets(assets_root, include_cards={"Strike.png": False})
+    python_root = tmp_path / "python"
+    _prepare_python_source(python_root)
+
+    with pytest.raises(BaseModBootstrapError) as excinfo:
+        DummyCharacter.createMod(
+            tmp_path / "dist",
+            assets_root=assets_root,
+            python_source=python_root,
+            bundle=False,
+        )
+    message = str(excinfo.value)
+    assert "Missing assets for cards" in message
+    assert "Strike" in message
+
+
+def test_character_enforces_card_counts_and_ratio(tmp_path: Path, use_real_dependencies: bool) -> None:
+    class StarterDeck(Deck):
+        pass
+
+    for index in range(10):
+        StarterDeck.addCard(_make_blueprint(f"Strike{index}"))
+
+    class UnlockableDeck(Deck):
+        pass
+
+    for index in range(10, 20):
+        UnlockableDeck.addCard(_make_blueprint(f"Strike{index}"))
+
+    class DummyCharacter(_BaseTestCharacter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.start.deck = StarterDeck
+            self.unlockableDeck = UnlockableDeck
+
+    assets_root = tmp_path / "assets" / "buddy"
+    include_cards = {f"Strike{index}.png": True for index in range(20)}
+    _prepare_assets(assets_root, include_cards=include_cards)
+    python_root = tmp_path / "python"
+    _prepare_python_source(python_root)
+
+    with pytest.raises(BaseModBootstrapError) as excinfo:
+        DummyCharacter.createMod(
+            tmp_path / "dist",
+            assets_root=assets_root,
+            python_source=python_root,
+            bundle=False,
+        )
+    message = str(excinfo.value)
+    assert "This deck has 20 cards." in message
+    assert "Card Rarity Proportions Incorrect" in message
+
+
+def test_static_spine_assets_are_generated(tmp_path: Path, use_real_dependencies: bool) -> None:
+    class StarterDeck(Deck):
+        pass
+
+    for index in range(60):
+        StarterDeck.addCard(_make_blueprint(f"Common{index}", rarity="common"))
+
+    class UnlockableDeck(Deck):
+        pass
+
+    for index in range(37):
+        UnlockableDeck.addCard(_make_blueprint(f"Uncommon{index}", rarity="uncommon"))
+    for index in range(3):
+        UnlockableDeck.addCard(_make_blueprint(f"Rare{index}", rarity="rare"))
+
+    class DummyCharacter(_BaseTestCharacter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.start.deck = StarterDeck
+            self.unlockableDeck = UnlockableDeck
+            self.image.staticspineanimation = "buddy/images/character/pose.png"
+
+    assets_root = tmp_path / "assets" / "buddy"
+    include_cards = {f"Common{index}.png": True for index in range(60)}
+    include_cards.update({f"Uncommon{index}.png": True for index in range(37)})
+    include_cards.update({f"Rare{index}.png": True for index in range(3)})
+    _prepare_assets(assets_root, include_cards=include_cards, include_static=True)
+    python_root = tmp_path / "python"
+    _prepare_python_source(python_root)
+
+    expected_atlas = assets_root / "images" / "character" / "pose.atlas"
+    expected_json = assets_root / "images" / "character" / "pose.json"
+
+    result = DummyCharacter.createMod(
+        tmp_path / "dist",
+        assets_root=assets_root,
+        python_source=python_root,
+        bundle=False,
+        register_cards=False,
+    )
+
+    assert result == (tmp_path / "dist" / "Buddy")
+    assert expected_atlas.exists()
+    assert expected_json.exists()
+    character = DummyCharacter()
+    character.image.staticspineanimation = "buddy/images/character/pose.png"
+    Character._prepare_static_spine(character, assets_root)
+    assert character.image.staticspineatlas.endswith("pose.atlas")
+    assert character.image.staticspinejson.endswith("pose.json")


### PR DESCRIPTION
## Summary
- add a `modules.modbuilder` package that exposes reusable `Deck` and `Character` base classes with validation helpers
- extend `CharacterBlueprint` to support static spine atlases/json files and generate them automatically when requested
- document the static pose workflow and cover the new authoring API with dedicated tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dbd2df9d348327bb724f42f9c9e8df