### PR TITLE
feat: expand keyword runtime and power tooling

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -81,6 +81,19 @@ that the scheduler wires into BaseMod subscribers, and surface the registration
 points on ``PLUGIN_MANAGER`` so third-party extensions can augment the event
 matrix without monkeypatching the core implementation.
 
+## Power instantiation metadata registry
+
+The heuristic-based power instantiation in `modules.basemod_wrapper.keywords`
+works for the majority of base game powers but still guesses constructor
+signatures at runtime. Introduce a metadata registry that enumerates the known
+constructor signatures for Slay the Spire powers and exposes an override hook
+for modded ones. Usage: ship a JSON manifest under ``research/`` describing the
+expected positional parameters, whether a power consumes the player as source,
+and any supplementary flags (e.g. `isSourceMonster`). `KeywordContext` would
+consult the registry before falling back to heuristics, while plugins could
+register additional entries via ``PLUGIN_MANAGER.expose(...)`` to guarantee
+future compatibility.
+
 ## Character builder scaffolding
 
 Teach the high-level `Character` helper to generate self-contained runtime

--- a/research/power_constructors_overview.md
+++ b/research/power_constructors_overview.md
@@ -1,0 +1,32 @@
+# Slay the Spire base power constructor cheatsheet
+
+The table summarises the constructor signatures for the most commonly used
+player and enemy powers referenced by the keyword runtime. Source material is
+the BaseMod and Slay the Spire open-source references mirrored in the
+`research/stslib_*` snapshots already tracked in this repository.
+
+| Power | Constructor signature | Notes |
+| --- | --- | --- |
+| StrengthPower | `(AbstractCreature owner, int amount)` | Negative amounts reduce strength. |
+| DexterityPower | `(AbstractCreature owner, int amount)` | Works on player and monsters. |
+| FocusPower | `(AbstractCreature owner, int amount)` | Defect-specific orb modifier. |
+| ArtifactPower | `(AbstractCreature owner, int amount)` | Prevents debuffs, stacks additively. |
+| IntangiblePlayerPower | `(AbstractCreature owner, int amount)` | Player-only intangible. |
+| IntangiblePower | `(AbstractCreature owner, int amount)` | Monster intangible (e.g. Transient). |
+| WeakPower | `(AbstractCreature owner, int amount, boolean isSourceMonster)` | `isSourceMonster` false when applied by the player. |
+| VulnerablePower | `(AbstractCreature owner, int amount, boolean isSourceMonster)` | Works like Weak. |
+| FrailPower | `(AbstractCreature owner, int amount)` | No source flag required. |
+| PoisonPower | `(AbstractCreature owner, AbstractCreature source, int amount)` | `source` identifies the attacker for artifact interactions. |
+| ConstrictedPower | `(AbstractCreature owner, AbstractCreature source, int amount)` | Primarily used by Snecko. |
+| ShackledPower | `(AbstractCreature owner, int amount)` | Temporarily reduces strength. |
+| LockOnPower | `(AbstractCreature owner, int amount)` | Orb targeting debuff. |
+| SlowPower | `(AbstractCreature owner, int amount)` | Stacks by the number of cards played. |
+| ThornsPower | `(AbstractCreature owner, int amount)` | Damages attackers on contact. |
+| PlatedArmorPower | `(AbstractCreature owner, int amount)` | Grants block at end of turn. |
+| MetallicizePower | `(AbstractCreature owner, int amount)` | Adds block each turn without decaying. |
+
+For powers with optional boolean flags, the keyword runtime defaults to
+`False`, matching the standard behaviour when the player applies the debuff to
+enemies. When creating custom powers, register the expected constructor
+signature via the forthcoming metadata registry described in `futures.md` so
+the runtime can instantiate modded powers deterministically.


### PR DESCRIPTION
## Summary
- expand the keyword runtime with runtime handles, power/enemy helpers, and richer card editing utilities
- expose the new helpers through the global plugin manager and document follow-up power metadata work
- add a power constructor research cheat sheet to back the extended keyword API tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd90f0e5483278e9ec8f84adb953a