### PR TITLE
Enhance deck analytics and character validation flow

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -111,3 +111,12 @@ Usage: extend the card asset pipeline with a lightweight audit log that captures
 blueprint identifiers, source digests and resolved resource paths, then surface
 a `PLUGIN_MANAGER` broadcast so tooling plugins can surface progress bars or
 regeneration prompts.
+
+## Deck analytics visualiser
+
+Now that `Deck.statistics()` surfaces immutable summaries for every declared
+deck, build a small analytics surface that can be reused by command line tools
+and plugins. Usage: add a reporting helper that converts the statistics into
+tabular data and optionally emits JSON artefacts for dashboards. Plugins should
+be able to subscribe to the `CHARACTER_VALIDATION_HOOK` broadcast and enrich the
+report with archetype heuristics and synergy hints for designers.

--- a/modules/modbuilder/__init__.py
+++ b/modules/modbuilder/__init__.py
@@ -1,20 +1,36 @@
 from __future__ import annotations
 
-from .deck import Deck
-from .character import Character, CharacterColorConfig, CharacterImageConfig, CharacterStartConfig
+from .deck import Deck, DeckStatistics
+from .character import (
+    CHARACTER_VALIDATION_HOOK,
+    Character,
+    CharacterColorConfig,
+    CharacterDeckSnapshot,
+    CharacterImageConfig,
+    CharacterStartConfig,
+    CharacterValidationReport,
+)
 from plugins import PLUGIN_MANAGER
 
 PLUGIN_MANAGER.expose("Deck", Deck)
+PLUGIN_MANAGER.expose("DeckStatistics", DeckStatistics)
 PLUGIN_MANAGER.expose("Character", Character)
 PLUGIN_MANAGER.expose("CharacterStartConfig", CharacterStartConfig)
 PLUGIN_MANAGER.expose("CharacterImageConfig", CharacterImageConfig)
 PLUGIN_MANAGER.expose("CharacterColorConfig", CharacterColorConfig)
+PLUGIN_MANAGER.expose("CharacterDeckSnapshot", CharacterDeckSnapshot)
+PLUGIN_MANAGER.expose("CharacterValidationReport", CharacterValidationReport)
+PLUGIN_MANAGER.expose("CHARACTER_VALIDATION_HOOK", CHARACTER_VALIDATION_HOOK)
 PLUGIN_MANAGER.expose_module("modules.modbuilder")
 
 __all__ = [
     "Deck",
+    "DeckStatistics",
     "Character",
     "CharacterStartConfig",
     "CharacterImageConfig",
     "CharacterColorConfig",
+    "CharacterDeckSnapshot",
+    "CharacterValidationReport",
+    "CHARACTER_VALIDATION_HOOK",
 ]


### PR DESCRIPTION
## Summary
- add immutable `DeckStatistics` snapshots for deck analytics and expose them through the plugin manager
- restructure `Character.createMod` to use new `collect_cards`/`validate` helpers and broadcast plugin validation hooks
- expand test coverage for deck statistics, validation snapshots, and plugin-integrated validation workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbe4d0e9f48327a490d59f5b61e3a9