### PR TITLE
Document mod loading workflows for bundled character mods

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -124,3 +124,11 @@ report with archetype heuristics and synergy hints for designers.
 ## How-to recipe synchroniser
 
 Link the new `how to/` recipes with runnable sample projects so documentation never drifts from the code. Usage: add a `modules.tools.recipes` helper that parses the Markdown snippets, materialises temporary mods with `Deck`, `Character`, and `Keyword`, and exposes a CLI (`python -m modules.tools.recipes verify how to/basic-character.md`) to ensure examples still compile and bundle. Plugins should receive a broadcast before and after verification so they can contribute extra validation or telemetry.
+
+## Launcher profile validation helpers
+
+Automate sanity checks for the two launcher flows documented in `how to/load-and-play-mod.md`.
+Usage: extend the bundler with an optional `validate_launchers` flag that inspects the
+ModTheSpire output directory and Steam Workshop subscriptions via the Steam Web API so
+scripts can warn if required utilities (ModTheSpire, BaseMod, StSLib) are missing before
+testers try to run the game.

--- a/how to/load-and-play-mod.md
+++ b/how to/load-and-play-mod.md
@@ -1,0 +1,76 @@
+# Load and play your bundled character mod
+
+You already have a runnable JAR thanks to `Character.createMod` and the `compileandbundle`
+helpers shown in the other recipes. The remaining question is: how do you boot the game
+with that package active? This guide covers both supported launch flows – the classic
+ModTheSpire launcher and Slay the Spire's Steam Workshop driven mod manager – so your
+team can test builds regardless of their preferred workflow.
+
+## 1. Produce the distributable JAR with the high-level bundler
+
+1. Keep using the turnkey builders – `Deck`, `Character`, and `Character.createMod` – to
+   assemble the project. When you are ready to test, call the bundler with `bundle=True`
+   so the helper writes the ModTheSpire manifest, copies Python support files and emits
+   the final JAR in one pass.
+
+   ```python
+   from pathlib import Path
+
+   from modules.modbuilder import Character
+
+   class Buddy(Character):
+       ...  # as defined in the basic character walkthrough
+
+   output_dir = Path("dist")
+   bundle_path = Buddy.createMod(
+       output_dir,
+       assets_root=Path("resources/Buddy"),
+       python_source=Path("python"),
+       bundle=True,
+   )
+   print(f"Your mod jar lives at {bundle_path}")
+   ```
+
+2. The call above returns the directory containing your compiled `.jar`. Copy that file to
+your clipboard – both launchers expect to find it inside the game's `mods/` folder.
+
+## 2. Launch through ModTheSpire's desktop app
+
+1. Download the latest ModTheSpire release and drop `ModTheSpire.jar` (plus `MTS.cmd`
+   on Windows or `MTS.sh` on Linux) into the Slay the Spire install directory.
+2. Create a `mods` subfolder next to the launcher (if it does not already exist) and copy
+   your bundled `.jar` into the folder alongside dependencies such as `BaseMod.jar`.
+3. Double-click `MTS.cmd`/`MTS.sh` (or run `java -jar ModTheSpire.jar` with Java 8).
+   The ModTheSpire window lists every JAR inside `mods/`. Tick your mod and press **Play**
+   to boot the game with the bundle enabled.
+4. Whenever you rebuild the mod, replace the JAR in `mods/` and rerun ModTheSpire.
+   The launcher remembers your previous selection so regression testing stays quick.
+
+## 3. Launch through the Steam Workshop mod manager
+
+1. Ask teammates to subscribe to the ModTheSpire and BaseMod utilities on the Steam
+   Workshop. Steam keeps both utilities updated and exposes a Mods toggle screen inside
+   the game.
+2. Copy your freshly built `.jar` into `%STEAMLIBRARY%/steamapps/common/SlayTheSpire/mods`
+   (the same location ModTheSpire uses). Workshop subscriptions ensure the loader and
+   BaseMod appear automatically in the in-game mod list.
+3. Start Slay the Spire from Steam. On the title screen choose **Mods** (or the **Play
+   with Mods** button on the launcher). A checklist displays all subscribed and locally
+   installed JARs. Tick your mod, ensure dependencies such as BaseMod stay enabled, then
+   click **Play** to launch the modded client.
+4. When Steam finishes updating a workshop item or you replace your mod's JAR, restart the
+   game and retick the mod if the manager prompts you. That guarantees everyone is testing
+   against the same build.
+
+## 4. Verify the mod is live in-game
+
+- The title screen shows "Modded" under the version number when ModTheSpire loads your
+  project correctly.
+- Custom characters created through `Character.createMod` appear in the character select
+  carousel. Load a new run, confirm starter decks, and run through combat to validate
+  card behaviours exposed by `Deck.statistics()` in your build scripts.
+- Use the mod manager to disable the package temporarily if you need to compare behaviour
+  with the vanilla game.
+
+With both launchers covered, everyone on the team can validate new builds without touching
+low-level BaseMod plumbing.

--- a/research/mod_loading_workflows.md
+++ b/research/mod_loading_workflows.md
@@ -1,0 +1,15 @@
+# Slay the Spire mod loading references
+
+## ModTheSpire launcher basics
+- Source: https://github.com/kiooeht/ModTheSpire/blob/master/README.md
+- Key points:
+  - Download latest release, copy `ModTheSpire.jar` (plus platform scripts) to Slay the Spire install directory.
+  - Create a `mods` directory next to the jar and place mod JARs inside.
+  - Run `ModTheSpire` (via `MTS.cmd`, `MTS.sh`, or directly with Java 8), select the mods to enable, then press **Play** to launch the game with those mods.
+
+## Steam Workshop mod launcher flow
+- Source: https://steamstore-a.akamaihd.net/news/externalpost/pcgamer/2551782186258323246
+- Key points:
+  - Steam Workshop lets players subscribe to ModTheSpire and BaseMod utilities alongside gameplay mods.
+  - When starting Slay the Spire after subscribing, the in-game mod manager lists subscribed mods so you can tick boxes to enable or untick to disable them.
+  - Workshop subscriptions keep utilities and gameplay mods updated automatically for the next launch.


### PR DESCRIPTION
## Summary
- add a new how-to that explains launching bundled mods via ModTheSpire and the Steam Workshop manager
- capture external launcher setup references inside research/mod_loading_workflows.md
- extend futures.md with a follow-up task for validating launcher prerequisites automatically

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dbf8308d488327bb16029b7e737092