### PR TITLE
Add multi-language localization support to simple cards

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -131,4 +131,11 @@
   the ModTheSpire output directory and Steam Workshop subscriptions via the
   Steam Web API so scripts can warn if required utilities (ModTheSpire,
   BaseMod, StSLib) are missing before testers try to run the game.
+- [todo] **Localization consistency audits** – Now that simple cards can emit
+  multilingual `cards.json` payloads, add a tooling pass that compares the
+  generated files against existing assets and highlights missing or stale
+  translations. Usage: surface a `modules.tools.localization.audit()` helper
+  that scans the `assets/<mod_id>/localizations` tree, reports cards that only
+  exist in a subset of languages, and exposes a plugin hook so translation
+  workflows can gate builds when required locales are incomplete.
 

--- a/modules/basemod_wrapper/README.md
+++ b/modules/basemod_wrapper/README.md
@@ -179,6 +179,7 @@ Each blueprint is a dataclass with the following key fields:
 | `card_uses` / `card_uses_upgrade` | Required for Exhaustive cards. Provides the base number of uses (and optional upgrade delta) that will be rendered via `{uses}`. |
 | `image` | Resource path used when you already have card art on disk. |
 | `inner_image_source` | Optional 500x380 image that will be processed into BaseMod-ready portrait/inner art pairs. |
+| `localizations` | Mapping of language codes (`eng`, `fra`, `zhs`, etc.) to dictionaries describing translated titles/descriptions. Missing languages fall back to the base `title`/`description`. |
 
 You can also call `blueprint.innerCardImage("art/Strike.png")` (or the snake
 case alias `inner_card_image`) to register a source image after initialisation.
@@ -253,10 +254,22 @@ combo = SimpleCardBlueprint(
     ],
     on_draw={"effect": "draw", "amount": 1},
     on_discard={"effect": "energy", "amount": 1},
+    localizations={
+        "fra": {
+            "title": "Combo d'âme",
+            "description": "Gagnez {block} Block. Appliquez {secondary} Faiblesse.",
+        }
+    },
 )
 
 PROJECT.add_simple_card(combo)
 ```
+
+Each localisation entry accepts optional `upgrade_description` and
+`extended_description` fields. Placeholder tokens (`{damage}`, `{block}`,
+`{secondary}`, etc.) are automatically converted into the appropriate Slay the
+Spire dynamic markers (for example `!D!`, `!B!`, `!M2!`) when localisation files
+are generated.
 
 When registered, the blueprint generates a full `CustomCard` subclass, wires the
 correct BaseMod/StSLib actions (`DamageAction`, `GainBlockAction`,

--- a/modules/basemod_wrapper/__init__.py
+++ b/modules/basemod_wrapper/__init__.py
@@ -11,7 +11,13 @@ from .loader import (
     ensure_jpype,
 )
 from .project import BundleOptions, ModProject, ProjectLayout, compileandbundle, create_project
-from .cards import SimpleCardBlueprint, register_simple_card
+from .cards import (
+    CardLocalizationEntry,
+    ResolvedCardLocalization,
+    SimpleCardBlueprint,
+    build_card_localizations,
+    register_simple_card,
+)
 from .keywords import (
     KEYWORD_REGISTRY,
     Keyword,
@@ -433,6 +439,9 @@ __all__ = [
     "BundleOptions",
     "create_project",
     "compileandbundle",
+    "build_card_localizations",
+    "CardLocalizationEntry",
+    "ResolvedCardLocalization",
     "SimpleCardBlueprint",
     "register_simple_card",
     "Keyword",


### PR DESCRIPTION
## Summary
- add localisation data structures and helper utilities to `SimpleCardBlueprint`
- persist generated card localisations during `Character.createMod` runs
- document the workflow and add regression tests covering localisation output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc0f5437808327993e39f7bfaaadd2