### PR TITLE
Document Python runtime activation and add bootstrap helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ directly to Python developers.
 - High level project system for declaring characters, card colours and cards via `ModProject`.
 - Declarative `SimpleCardBlueprint` helper that builds everyday attacks, skills and powers without boilerplate.
 - Turn-key bundling through `compileandbundle` which writes ModTheSpire manifests, Java enum patches and copies Python assets.
+- Runtime bootstrap helpers (`modules.modbuilder.runtime_env`) that describe bundled Python packages and generate platform-specific activation commands.
 - Forward-looking roadmap documented in `futures.md`.
 - Built-in deck analytics helper that converts validation snapshots into tables and JSON artefacts for dashboards and plugins.
 

--- a/futures.md
+++ b/futures.md
@@ -138,4 +138,11 @@
   that scans the `assets/<mod_id>/localizations` tree, reports cards that only
   exist in a subset of languages, and exposes a plugin hook so translation
   workflows can gate builds when required locales are incomplete.
+- [todo] **Python runtime auto-launcher** – Ship a lightweight script alongside
+  bundles that reads `PythonRuntimeBootstrapPlan` metadata and toggles
+  `PYTHONPATH`, virtualenv activation and entrypoint invocation automatically
+  before spawning ModTheSpire. Usage: extend `modules.modbuilder.runtime_env`
+  with a CLI (`python -m modules.modbuilder.runtime_env launch <bundle>`)
+  that executes the bootstrap plan directly, saving testers from copying
+  commands and ensuring cross-platform consistency.
 

--- a/how to/load-and-play-mod.md
+++ b/how to/load-and-play-mod.md
@@ -31,10 +31,78 @@ team can test builds regardless of their preferred workflow.
    print(f"Your mod jar lives at {bundle_path}")
    ```
 
-2. The call above returns the directory containing your compiled `.jar`. Copy that file to
-your clipboard – both launchers expect to find it inside the game's `mods/` folder.
+2. The call above returns the directory containing your compiled `.jar`. Copy the **entire**
+   folder (including `python/`, `resources/`, `patches/` and the patch jar) – both launchers
+   expect to find every asset, including the Python package, inside the game's `mods/`
+   directory.
 
-## 2. Launch through ModTheSpire's desktop app
+## 2. Prepare the Python runtime that ships with the bundle
+
+The JPype bridge expects a live Python environment next to the jar. When you ship the bundle
+to teammates, they must keep the `python/` directory and provision an interpreter that can
+import `python/<package>/entrypoint.py`. A reliable activation flow looks like this:
+
+1. **Create a virtual environment** dedicated to the mod.
+   - macOS/Linux:
+     ```bash
+     python3 -m venv /path/to/SlayTheSpire/mods/BuddyMod/.venv
+     ```
+   - Windows (PowerShell or `cmd.exe`):
+     ```powershell
+     py -3 -m venv C:\Games\SlayTheSpire\mods\BuddyMod\.venv
+     ```
+2. **Install JPype and your dependencies** into that environment. If your Python package
+   already ships a `requirements.txt`, use it. Otherwise install JPype manually.
+   - macOS/Linux:
+     ```bash
+     /path/to/SlayTheSpire/mods/BuddyMod/.venv/bin/pip install -r python/requirements.txt
+     ```
+     *(Fallback if no requirements file exists: `.../pip install JPype1`)*
+   - Windows:
+     ```powershell
+     C:\Games\SlayTheSpire\mods\BuddyMod\.venv\Scripts\pip.exe install -r python\requirements.txt
+     ```
+3. **Expose the bundled sources via `PYTHONPATH`** so the entrypoint resolves regardless of
+   the working directory.
+   - macOS/Linux:
+     ```bash
+     export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}/path/to/SlayTheSpire/mods/BuddyMod/python"
+     ```
+   - Windows:
+     ```cmd
+     set PYTHONPATH=%PYTHONPATH%;C:\Games\SlayTheSpire\mods\BuddyMod\python
+     ```
+4. **Sanity-check the entrypoint** before booting the game. Activating it once registers all
+   BaseMod hooks through `Character.enable_runtime()`.
+   - macOS/Linux:
+     ```bash
+     /path/to/SlayTheSpire/mods/BuddyMod/.venv/bin/python -m buddy_mod.entrypoint
+     ```
+   - Windows:
+     ```powershell
+     C:\Games\SlayTheSpire\mods\BuddyMod\.venv\Scripts\python.exe -m buddy_mod.entrypoint
+     ```
+
+If you prefer generating the commands programmatically, the new
+`modules.modbuilder.runtime_env.discover_python_runtime` helper inspects the bundled folder
+and prints a ready-to-run bootstrap plan:
+
+```python
+from pathlib import Path
+
+from modules.modbuilder.runtime_env import discover_python_runtime
+
+bundle_root = Path("/path/to/SlayTheSpire/mods/BuddyMod")
+descriptor = discover_python_runtime(bundle_root)
+plan = descriptor.bootstrap_plan()
+
+for command in plan.posix.commands():
+    print(command)
+```
+
+Use `plan.windows.commands()` when preparing instructions for teammates on Windows.
+
+## 3. Launch through ModTheSpire's desktop app
 
 1. Download the latest ModTheSpire release and drop `ModTheSpire.jar` (plus `MTS.cmd`
    on Windows or `MTS.sh` on Linux) into the Slay the Spire install directory.
@@ -46,7 +114,7 @@ your clipboard – both launchers expect to find it inside the game's `mods/` fo
 4. Whenever you rebuild the mod, replace the JAR in `mods/` and rerun ModTheSpire.
    The launcher remembers your previous selection so regression testing stays quick.
 
-## 3. Launch through the Steam Workshop mod manager
+## 4. Launch through the Steam Workshop mod manager
 
 1. Ask teammates to subscribe to the ModTheSpire and BaseMod utilities on the Steam
    Workshop. Steam keeps both utilities updated and exposes a Mods toggle screen inside
@@ -62,7 +130,7 @@ your clipboard – both launchers expect to find it inside the game's `mods/` fo
    game and retick the mod if the manager prompts you. That guarantees everyone is testing
    against the same build.
 
-## 4. Verify the mod is live in-game
+## 5. Verify the mod is live in-game
 
 - The title screen shows "Modded" under the version number when ModTheSpire loads your
   project correctly.

--- a/modules/modbuilder/__init__.py
+++ b/modules/modbuilder/__init__.py
@@ -11,6 +11,12 @@ from .character import (
     CharacterStartConfig,
     CharacterValidationReport,
 )
+from .runtime_env import (
+    PlatformBootstrap,
+    PythonRuntimeBootstrapPlan,
+    PythonRuntimeDescriptor,
+    discover_python_runtime,
+)
 from plugins import PLUGIN_MANAGER
 
 PLUGIN_MANAGER.expose("Deck", Deck)
@@ -27,6 +33,10 @@ PLUGIN_MANAGER.expose("CharacterColorConfig", CharacterColorConfig)
 PLUGIN_MANAGER.expose("CharacterDeckSnapshot", CharacterDeckSnapshot)
 PLUGIN_MANAGER.expose("CharacterValidationReport", CharacterValidationReport)
 PLUGIN_MANAGER.expose("CHARACTER_VALIDATION_HOOK", CHARACTER_VALIDATION_HOOK)
+PLUGIN_MANAGER.expose("discover_python_runtime", discover_python_runtime)
+PLUGIN_MANAGER.expose("PythonRuntimeDescriptor", PythonRuntimeDescriptor)
+PLUGIN_MANAGER.expose("PythonRuntimeBootstrapPlan", PythonRuntimeBootstrapPlan)
+PLUGIN_MANAGER.expose("PlatformBootstrap", PlatformBootstrap)
 PLUGIN_MANAGER.expose_module("modules.modbuilder")
 
 __all__ = [
@@ -44,4 +54,8 @@ __all__ = [
     "CharacterDeckSnapshot",
     "CharacterValidationReport",
     "CHARACTER_VALIDATION_HOOK",
+    "discover_python_runtime",
+    "PythonRuntimeDescriptor",
+    "PythonRuntimeBootstrapPlan",
+    "PlatformBootstrap",
 ]

--- a/modules/modbuilder/runtime_env.py
+++ b/modules/modbuilder/runtime_env.py
@@ -1,0 +1,310 @@
+"""Helpers for inspecting and bootstrapping bundled Python runtimes.
+
+This module makes it easier for documentation and tooling to instruct
+teammates on how to activate the Python half of a bundled mod.  Bundles
+produced by :func:`modules.modbuilder.Character.createMod` ship the Python
+package next to the compiled patch jar.  Testers still need to provision a
+Python interpreter with JPype installed and make sure the generated
+``entrypoint`` module is reachable at game launch.
+
+The helpers below keep that workflow declarative:
+
+* :func:`discover_python_runtime` inspects a bundle directory and returns a
+  :class:`PythonRuntimeDescriptor` describing the Python package, entrypoint
+  module and any dependency manifests (``requirements.txt`` / ``pyproject``).
+* :class:`PythonRuntimeDescriptor.bootstrap_plan` manufactures
+  copy-paste-ready command sequences for POSIX and Windows shells so teams can
+  set up virtual environments, install JPype and point ``PYTHONPATH`` at the
+  bundled sources without guesswork.
+
+The functions are exported through the global plugin manager so downstream
+tooling and documentation renderers can surface the same guidance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import shlex
+from typing import Dict, Iterator, List, Optional, Tuple
+
+from plugins import PLUGIN_MANAGER
+
+
+class PythonRuntimeError(RuntimeError):
+    """Raised when a bundled Python runtime cannot be resolved."""
+
+
+def _posix_quote(path: Path | str) -> str:
+    """Return a shell-escaped representation suitable for POSIX shells."""
+
+    return shlex.quote(str(path))
+
+
+def _windows_quote(path: Path | str) -> str:
+    """Return a quoted representation suitable for ``cmd.exe``."""
+
+    text = str(path)
+    if not text:
+        return '""'
+    if text.startswith('"') and text.endswith('"'):
+        return text
+    return f'"{text}"'
+
+
+def _iter_requirement_files(python_root: Path, package_root: Path) -> Iterator[Path]:
+    """Yield requirement manifests shipped with the bundle."""
+
+    searched: set[Path] = set()
+    candidate_dirs: Tuple[Path, ...] = (
+        python_root,
+        package_root,
+        package_root.parent,
+    )
+    names: Tuple[str, ...] = (
+        "requirements.txt",
+        "requirements-dev.txt",
+        "requirements-dev.in",
+        "requirements.in",
+    )
+    for directory in candidate_dirs:
+        for name in names:
+            candidate = directory / name
+            if candidate.exists() and candidate not in searched:
+                searched.add(candidate)
+                yield candidate
+
+
+def _iter_editable_targets(package_root: Path) -> Iterator[Path]:
+    """Yield package directories that should be installed in editable mode."""
+
+    markers = ("pyproject.toml", "setup.cfg", "setup.py")
+    for marker in markers:
+        if (package_root / marker).exists():
+            yield package_root
+            break
+
+
+@dataclass(frozen=True)
+class PlatformBootstrap:
+    """Command set tailored for a particular operating system."""
+
+    create_virtualenv: str
+    install_dependencies: Tuple[str, ...]
+    configure_pythonpath: str
+    verify_runtime: str
+
+    def commands(self) -> Tuple[str, ...]:
+        """Return the commands in execution order."""
+
+        return (
+            self.create_virtualenv,
+            *self.install_dependencies,
+            self.configure_pythonpath,
+            self.verify_runtime,
+        )
+
+
+@dataclass(frozen=True)
+class PythonRuntimeBootstrapPlan:
+    """Concrete instructions for getting the Python runtime ready."""
+
+    descriptor: "PythonRuntimeDescriptor"
+    venv_directory: Path
+    posix: PlatformBootstrap
+    windows: PlatformBootstrap
+
+    def environment_variables(self) -> Dict[str, str]:
+        """Return environment variables required for launching the mod."""
+
+        return {"PYTHONPATH": str(self.descriptor.python_root)}
+
+    def as_dict(self) -> Dict[str, object]:
+        """Serialise the plan for docs, logging or JSON output."""
+
+        return {
+            "package": self.descriptor.package_name,
+            "entrypoint": str(self.descriptor.entrypoint),
+            "python_root": str(self.descriptor.python_root),
+            "venv_directory": str(self.venv_directory),
+            "posix": {
+                "create_virtualenv": self.posix.create_virtualenv,
+                "install_dependencies": list(self.posix.install_dependencies),
+                "configure_pythonpath": self.posix.configure_pythonpath,
+                "verify_runtime": self.posix.verify_runtime,
+            },
+            "windows": {
+                "create_virtualenv": self.windows.create_virtualenv,
+                "install_dependencies": list(self.windows.install_dependencies),
+                "configure_pythonpath": self.windows.configure_pythonpath,
+                "verify_runtime": self.windows.verify_runtime,
+            },
+            "environment": self.environment_variables(),
+        }
+
+
+@dataclass(frozen=True)
+class PythonRuntimeDescriptor:
+    """High level description of the Python runtime shipped with a bundle."""
+
+    bundle_root: Path
+    python_root: Path
+    package_name: str
+    package_root: Path
+    entrypoint: Path
+    requirement_files: Tuple[Path, ...]
+    editable_targets: Tuple[Path, ...]
+
+    def bootstrap_plan(
+        self,
+        *,
+        venv_directory: Optional[Path] = None,
+        python_launcher_posix: str = "python3",
+        python_launcher_windows: str = "py -3",
+    ) -> PythonRuntimeBootstrapPlan:
+        """Return command sequences for activating the runtime.
+
+        ``python_launcher_posix`` and ``python_launcher_windows`` allow callers to
+        tailor the bootstrap commands to their team's conventions (for example
+        substituting ``python`` for ``python3`` on macOS).
+        """
+
+        venv_directory = venv_directory or (self.bundle_root / ".venv")
+
+        posix_install: List[str] = []
+        windows_install: List[str] = []
+
+        pip_posix = venv_directory / "bin" / "pip"
+        pip_windows = venv_directory / "Scripts" / "pip.exe"
+
+        requirement_args_posix: List[str] = []
+        requirement_args_windows: List[str] = []
+        for requirement in self.requirement_files:
+            requirement_args_posix.append(f"-r {_posix_quote(requirement)}")
+            requirement_args_windows.append(f"-r {_windows_quote(requirement)}")
+
+        if requirement_args_posix:
+            posix_install.append(
+                f"{_posix_quote(pip_posix)} install {' '.join(requirement_args_posix)}"
+            )
+            windows_install.append(
+                f"{_windows_quote(pip_windows)} install {' '.join(requirement_args_windows)}"
+            )
+
+        for editable in self.editable_targets:
+            posix_install.append(
+                f"{_posix_quote(pip_posix)} install -e {_posix_quote(editable)}"
+            )
+            windows_install.append(
+                f"{_windows_quote(pip_windows)} install -e {_windows_quote(editable)}"
+            )
+
+        if not posix_install:
+            posix_install.append(f"{_posix_quote(pip_posix)} install JPype1")
+        if not windows_install:
+            windows_install.append(f"{_windows_quote(pip_windows)} install JPype1")
+
+        python_posix = venv_directory / "bin" / "python"
+        python_windows = venv_directory / "Scripts" / "python.exe"
+
+        posix = PlatformBootstrap(
+            create_virtualenv=f"{python_launcher_posix} -m venv {_posix_quote(venv_directory)}",
+            install_dependencies=tuple(posix_install),
+            configure_pythonpath=(
+                "export PYTHONPATH=\"${PYTHONPATH:+$PYTHONPATH:}" f"{_posix_quote(self.python_root)}\""
+            ),
+            verify_runtime=f"{_posix_quote(python_posix)} -m {self.package_name}.entrypoint",
+        )
+
+        windows = PlatformBootstrap(
+            create_virtualenv=f"{python_launcher_windows} -m venv {_windows_quote(venv_directory)}",
+            install_dependencies=tuple(windows_install),
+            configure_pythonpath=(
+                f"set PYTHONPATH=%PYTHONPATH%;{_windows_quote(self.python_root)}"
+            ),
+            verify_runtime=f"{_windows_quote(python_windows)} -m {self.package_name}.entrypoint",
+        )
+
+        return PythonRuntimeBootstrapPlan(self, venv_directory, posix, windows)
+
+
+def discover_python_runtime(bundle_root: Path, package_name: Optional[str] = None) -> PythonRuntimeDescriptor:
+    """Inspect ``bundle_root`` and describe the shipped Python runtime.
+
+    ``bundle_root`` should point to the directory produced by
+    :func:`modules.modbuilder.Character.createMod` (the folder that also houses
+    ``ModTheSpire.json`` and the compiled patch jar).
+    """
+
+    bundle_root = bundle_root.resolve()
+    if not bundle_root.exists():
+        raise PythonRuntimeError(f"Bundle directory '{bundle_root}' does not exist.")
+
+    python_root = bundle_root / "python"
+    if not python_root.exists():
+        raise PythonRuntimeError(
+            f"Bundle directory '{bundle_root}' does not contain a python/ folder."
+        )
+
+    candidates: Dict[str, Path] = {}
+    for child in python_root.iterdir():
+        if not child.is_dir():
+            continue
+        entrypoint = child / "entrypoint.py"
+        init_py = child / "__init__.py"
+        if entrypoint.exists() and init_py.exists():
+            candidates[child.name] = child
+
+    if not candidates:
+        raise PythonRuntimeError(
+            f"No Python package with an entrypoint.py was found under '{python_root}'."
+        )
+
+    target_name: Optional[str] = package_name
+    if target_name is None:
+        if len(candidates) > 1:
+            available = ", ".join(sorted(candidates))
+            raise PythonRuntimeError(
+                "Multiple Python packages were found. Specify package_name explicitly. "
+                f"Available packages: {available}."
+            )
+        target_name = next(iter(candidates))
+    if target_name not in candidates:
+        available = ", ".join(sorted(candidates))
+        raise PythonRuntimeError(
+            f"Package '{target_name}' not found in bundle. Available packages: {available}."
+        )
+
+    package_root = candidates[target_name]
+    entrypoint = package_root / "entrypoint.py"
+
+    requirement_files = tuple(_iter_requirement_files(python_root, package_root))
+    editable_targets = tuple(_iter_editable_targets(package_root))
+
+    descriptor = PythonRuntimeDescriptor(
+        bundle_root=bundle_root,
+        python_root=python_root,
+        package_name=target_name,
+        package_root=package_root,
+        entrypoint=entrypoint,
+        requirement_files=requirement_files,
+        editable_targets=editable_targets,
+    )
+    return descriptor
+
+
+PLUGIN_MANAGER.expose("discover_python_runtime", discover_python_runtime)
+PLUGIN_MANAGER.expose("PythonRuntimeDescriptor", PythonRuntimeDescriptor)
+PLUGIN_MANAGER.expose("PythonRuntimeBootstrapPlan", PythonRuntimeBootstrapPlan)
+PLUGIN_MANAGER.expose("PlatformBootstrap", PlatformBootstrap)
+PLUGIN_MANAGER.expose_module("modules.modbuilder.runtime_env")
+
+
+__all__ = [
+    "PythonRuntimeError",
+    "PlatformBootstrap",
+    "PythonRuntimeBootstrapPlan",
+    "PythonRuntimeDescriptor",
+    "discover_python_runtime",
+]
+

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+
+from modules.modbuilder.runtime_env import (
+    PythonRuntimeError,
+    discover_python_runtime,
+)
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_discover_python_runtime_generates_plan(tmp_path: Path, use_real_dependencies: bool) -> None:
+    bundle_root = tmp_path / "BuddyMod"
+    package_root = bundle_root / "python" / "buddy_mod"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("__all__ = []\n", encoding="utf8")
+    (package_root / "entrypoint.py").write_text("def initialize():\n    pass\n", encoding="utf8")
+    requirements = bundle_root / "python" / "requirements.txt"
+    requirements.write_text("JPype1==1.5.0\n", encoding="utf8")
+
+    descriptor = discover_python_runtime(bundle_root)
+    assert descriptor.package_name == "buddy_mod"
+    assert descriptor.entrypoint == package_root / "entrypoint.py"
+    assert descriptor.requirement_files == (requirements,)
+
+    plan = descriptor.bootstrap_plan()
+    assert plan.descriptor is descriptor
+    assert plan.venv_directory == bundle_root / ".venv"
+
+    posix_commands = plan.posix.commands()
+    windows_commands = plan.windows.commands()
+
+    assert any("requirements.txt" in command for command in posix_commands)
+    assert any("buddy_mod.entrypoint" in command for command in windows_commands)
+
+    environment = plan.environment_variables()
+    assert environment["PYTHONPATH"].endswith("python")
+
+    serialised = plan.as_dict()
+    assert serialised["package"] == "buddy_mod"
+    assert serialised["entrypoint"].endswith("entrypoint.py")
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_discover_python_runtime_requires_entrypoint(tmp_path: Path, use_real_dependencies: bool) -> None:
+    bundle_root = tmp_path / "BuddyMod"
+    package_root = bundle_root / "python" / "buddy_mod"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("__all__ = []\n", encoding="utf8")
+
+    with pytest.raises(PythonRuntimeError):
+        discover_python_runtime(bundle_root)
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_bootstrap_plan_falls_back_to_jpype(tmp_path: Path, use_real_dependencies: bool) -> None:
+    bundle_root = tmp_path / "BuddyMod"
+    package_root = bundle_root / "python" / "buddy_mod"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("__all__ = []\n", encoding="utf8")
+    (package_root / "entrypoint.py").write_text("def initialize():\n    pass\n", encoding="utf8")
+
+    descriptor = discover_python_runtime(bundle_root)
+    plan = descriptor.bootstrap_plan()
+
+    assert any("JPype1" in command for command in plan.posix.install_dependencies)
+    assert any("JPype1" in command for command in plan.windows.install_dependencies)


### PR DESCRIPTION
## Summary
- add `modules.modbuilder.runtime_env` helpers to describe bundled Python packages and generate cross-platform bootstrap commands
- expose the helpers through the global plugin surface and cover them with regression tests
- expand the load-and-play guide and README to document the Python runtime workflow and record a follow-up automation idea

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc3590d6cc8327a6eadc2814863350