### PR TITLE
Add automatic mod bootstrapper and launch CLI

### DIFF
--- a/bootstrap_mod.py
+++ b/bootstrap_mod.py
@@ -1,0 +1,22 @@
+"""One-click bootstrapper for bundled Slay the Spire mods."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from modules.modbuilder.runtime_env import bootstrap_python_runtime
+
+
+def main() -> None:
+    bundle_root = Path.cwd()
+    descriptor = bootstrap_python_runtime(bundle_root)
+    print(
+        "Python runtime initialised for '",
+        descriptor.package_name,
+        "' at ",
+        bundle_root / ".venv",
+        sep="",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/futures.md
+++ b/futures.md
@@ -36,6 +36,12 @@
   payload into validation reports, `tests/test_modbuilder.py` verifies the
   integration, and `how to/deck-analytics.md` walks contributors through real
   world usage.
+- [complete] **Python runtime auto-launcher** – Bundles write
+  `bootstrap_mod.py` via `modules.modbuilder.runtime_env.write_runtime_bootstrapper`
+  so testers can run `python bootstrap_mod.py` to provision the `.venv` and
+  execute the entrypoint. The executable workflow is covered by
+  `modules.modbuilder.runtime_env.bootstrap_python_runtime` and documented in
+  `how to/load-and-play-mod.md`.
 
 ## Upcoming work
 
@@ -138,11 +144,4 @@
   that scans the `assets/<mod_id>/localizations` tree, reports cards that only
   exist in a subset of languages, and exposes a plugin hook so translation
   workflows can gate builds when required locales are incomplete.
-- [todo] **Python runtime auto-launcher** – Ship a lightweight script alongside
-  bundles that reads `PythonRuntimeBootstrapPlan` metadata and toggles
-  `PYTHONPATH`, virtualenv activation and entrypoint invocation automatically
-  before spawning ModTheSpire. Usage: extend `modules.modbuilder.runtime_env`
-  with a CLI (`python -m modules.modbuilder.runtime_env launch <bundle>`)
-  that executes the bootstrap plan directly, saving testers from copying
-  commands and ensuring cross-platform consistency.
 

--- a/modules/basemod_wrapper/project.py
+++ b/modules/basemod_wrapper/project.py
@@ -688,6 +688,9 @@ class ModProject:
 
         (mod_root / "ModTheSpire.json").write_text(self._render_modthespire_manifest(options))
         (mod_root / "README.txt").write_text(self._render_bundle_readme())
+        from modules.modbuilder.runtime_env import write_runtime_bootstrapper
+
+        write_runtime_bootstrapper(mod_root)
         return mod_root
 
     def _render_enum_patch(self) -> str:

--- a/modules/modbuilder/__init__.py
+++ b/modules/modbuilder/__init__.py
@@ -15,7 +15,10 @@ from .runtime_env import (
     PlatformBootstrap,
     PythonRuntimeBootstrapPlan,
     PythonRuntimeDescriptor,
+    bootstrap_python_runtime,
     discover_python_runtime,
+    execute_bootstrap_plan,
+    write_runtime_bootstrapper,
 )
 from plugins import PLUGIN_MANAGER
 
@@ -34,9 +37,12 @@ PLUGIN_MANAGER.expose("CharacterDeckSnapshot", CharacterDeckSnapshot)
 PLUGIN_MANAGER.expose("CharacterValidationReport", CharacterValidationReport)
 PLUGIN_MANAGER.expose("CHARACTER_VALIDATION_HOOK", CHARACTER_VALIDATION_HOOK)
 PLUGIN_MANAGER.expose("discover_python_runtime", discover_python_runtime)
+PLUGIN_MANAGER.expose("bootstrap_python_runtime", bootstrap_python_runtime)
+PLUGIN_MANAGER.expose("execute_bootstrap_plan", execute_bootstrap_plan)
 PLUGIN_MANAGER.expose("PythonRuntimeDescriptor", PythonRuntimeDescriptor)
 PLUGIN_MANAGER.expose("PythonRuntimeBootstrapPlan", PythonRuntimeBootstrapPlan)
 PLUGIN_MANAGER.expose("PlatformBootstrap", PlatformBootstrap)
+PLUGIN_MANAGER.expose("write_runtime_bootstrapper", write_runtime_bootstrapper)
 PLUGIN_MANAGER.expose_module("modules.modbuilder")
 
 __all__ = [
@@ -55,7 +61,10 @@ __all__ = [
     "CharacterValidationReport",
     "CHARACTER_VALIDATION_HOOK",
     "discover_python_runtime",
+    "bootstrap_python_runtime",
+    "execute_bootstrap_plan",
     "PythonRuntimeDescriptor",
     "PythonRuntimeBootstrapPlan",
     "PlatformBootstrap",
+    "write_runtime_bootstrapper",
 ]

--- a/tests/test_runtime_env.py
+++ b/tests/test_runtime_env.py
@@ -4,17 +4,70 @@ import pytest
 
 from modules.modbuilder.runtime_env import (
     PythonRuntimeError,
+    bootstrap_python_runtime,
     discover_python_runtime,
+    write_runtime_bootstrapper,
 )
 
 
-@pytest.mark.parametrize("use_real_dependencies", [False, True])
-def test_discover_python_runtime_generates_plan(tmp_path: Path, use_real_dependencies: bool) -> None:
+def _create_bundle(tmp_path: Path) -> Path:
     bundle_root = tmp_path / "BuddyMod"
     package_root = bundle_root / "python" / "buddy_mod"
     package_root.mkdir(parents=True)
     (package_root / "__init__.py").write_text("__all__ = []\n", encoding="utf8")
-    (package_root / "entrypoint.py").write_text("def initialize():\n    pass\n", encoding="utf8")
+    entrypoint = package_root / "entrypoint.py"
+    entrypoint.write_text(
+        """
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def main() -> None:
+    target = Path(__file__).resolve().parent / "entrypoint.log"
+    target.write_text(os.environ.get("PYTHONPATH", ""), encoding="utf8")
+
+
+if __name__ == "__main__":
+    main()
+""".strip()
+        + "\n",
+        encoding="utf8",
+    )
+    (package_root / "setup.cfg").write_text(
+        """
+[metadata]
+name = buddy-mod
+version = 0.0.0
+
+[options]
+packages = find:
+package_dir =
+    =.
+
+[options.packages.find]
+where = .
+""".strip()
+        + "\n",
+        encoding="utf8",
+    )
+    (package_root / "pyproject.toml").write_text(
+        """
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+""".strip()
+        + "\n",
+        encoding="utf8",
+    )
+    return bundle_root
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_discover_python_runtime_generates_plan(tmp_path: Path, use_real_dependencies: bool) -> None:
+    bundle_root = _create_bundle(tmp_path)
+    package_root = bundle_root / "python" / "buddy_mod"
     requirements = bundle_root / "python" / "requirements.txt"
     requirements.write_text("JPype1==1.5.0\n", encoding="utf8")
 
@@ -65,3 +118,46 @@ def test_bootstrap_plan_falls_back_to_jpype(tmp_path: Path, use_real_dependencie
 
     assert any("JPype1" in command for command in plan.posix.install_dependencies)
     assert any("JPype1" in command for command in plan.windows.install_dependencies)
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_bootstrap_python_runtime_executes_entrypoint(tmp_path: Path, use_real_dependencies: bool) -> None:
+    bundle_root = _create_bundle(tmp_path)
+    package_root = bundle_root / "python" / "buddy_mod"
+
+    if use_real_dependencies:
+        bootstrap_python_runtime(bundle_root, logger=lambda *_: None)
+
+    descriptor = bootstrap_python_runtime(bundle_root, logger=lambda *_: None)
+    assert descriptor.package_name == "buddy_mod"
+
+    venv_marker = bundle_root / ".venv" / "pyvenv.cfg"
+    assert venv_marker.exists()
+
+    log_file = package_root / "entrypoint.log"
+    assert log_file.exists()
+    content = log_file.read_text(encoding="utf8")
+    assert str(bundle_root / "python") in content
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_write_runtime_bootstrapper_creates_script(tmp_path: Path, use_real_dependencies: bool) -> None:
+    target = write_runtime_bootstrapper(tmp_path)
+    assert target.exists()
+    content = target.read_text(encoding="utf8")
+    assert "bootstrap_python_runtime" in content
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_runtime_env_cli_plan_outputs_json(tmp_path: Path, use_real_dependencies: bool, capsys: pytest.CaptureFixture[str]) -> None:
+    import json
+
+    from modules.modbuilder import runtime_env as runtime_env_module
+
+    bundle_root = _create_bundle(tmp_path)
+    exit_code = runtime_env_module._cli(["plan", str(bundle_root), "--json"])
+    assert exit_code == 0
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["package"] == "buddy_mod"


### PR DESCRIPTION
## Summary
- extend the runtime environment helpers with executable bootstrap and launch functions plus a CLI entry point
- emit a ready-to-run bootstrap_mod.py script into every bundle and document the simplified workflow
- add comprehensive tests that exercise the bootstrapper, CLI output, and helper script generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc3a4318748327ad4786f1ca5a5c9e