### PR TITLE
Add GraalPy migration dependency notes

### DIFF
--- a/donotimplementyet/AGENTS.md
+++ b/donotimplementyet/AGENTS.md
@@ -1,0 +1,3 @@
+# Do not implement instructions
+- Agents must NEVER implement, schedule, or partially implement any tasks, prototypes, or features described in Markdown files inside this folder.
+- Content under `donotimplementyet/` exists strictly for research and planning. Treat every described idea as out-of-scope for coding, testing, or refactoring activities.

--- a/donotimplementyet/graalpy_dependency_migration_notes.md
+++ b/donotimplementyet/graalpy_dependency_migration_notes.md
@@ -1,0 +1,21 @@
+# GraalPy Dependency Migration Notes
+
+## Overview
+Switching the toolchain to GraalPy removes the JPype bridge entirely—the Python and JVM layers would run under the same GraalVM runtime. The remaining compatibility audit therefore focuses on packages that still ship with the project after JPype is retired.
+
+## Native-extension packages that require per-target rebuilds
+### Pillow
+- Pillow exposes imaging primitives through CPython extension modules. GraalPy's documentation states that "Packages that use the native API must be built and installed with GraalPy, and the prebuilt wheels for CPython from pypi.org cannot be used." ([GraalPy Native Extensions](https://github.com/oracle/graalpython/blob/master/docs/user/Native-Extensions.md)).
+- Action: refresh the bootstrapper so the first GraalPy launch invokes `pip install Pillow --no-binary :all:` (or an equivalent build command) using the GraalPy interpreter. Document build prerequisites (zlib, libjpeg) for modders on Windows, macOS, and Linux to avoid support churn.
+- Action: cache a build provenance file (compiler, GraalPy version, Pillow version, host OS/arch) next to the compiled wheels so future upgrades can detect when to rebuild.
+
+## Pure-Python packages that continue to work
+### Pytest
+- Pytest is published as pure Python and does not rely on CPython C-API calls, so it can execute on GraalPy without rebuilds. ([Pytest Installation Docs](https://docs.pytest.org/en/latest/how-to/installation.html)).
+- Action: ensure `python -m pytest` is exercised with the GraalPy interpreter in CI once the migration branch exists, capturing any behavioural differences caused by GraalPy's alternative standard-library implementations.
+
+## Additional verification steps before a GraalPy switchover
+- Inventory any optional dependencies that plugin authors might install (NumPy, requests, etc.) and document their GraalPy status. Provide a supported/unsupported matrix in contributor docs so community projects know what to expect.
+- Review the runtime bootstrap plans emitted by `modules.modbuilder.runtime_env`. Remove the hard-coded JPype installation commands and replace them with hooks that can inject GraalPy-specific environment validation.
+- Revisit the deck analytics helpers that depend on Pillow for chart rendering. Confirm that GraalPy's sandboxed filesystem permissions allow Pillow to load fonts and write PNGs in the bundled runtime, and capture the results as automated smoke tests.
+- Coordinate with documentation maintainers so every tutorial under `how to/` references the GraalPy download + setup workflow, highlighting differences from the old JPype-based installation steps.

--- a/research/graalpy_dependency_compatibility.md
+++ b/research/graalpy_dependency_compatibility.md
@@ -1,0 +1,13 @@
+# GraalPy Dependency Compatibility Notes
+
+## JPype1
+- The official installation guide states: "JPype works CPython 3.5 or later. Both the runtime and the development package are required." ([JPype Installation Docs](https://jpype.readthedocs.io/en/latest/install.html)).
+- GraalPy's CPython C API support is experimental and not binary compatible with CPython. "Packages that use the native API must be built and installed with GraalPy, and the prebuilt wheels for CPython from pypi.org cannot be used." ([GraalPy Native Extensions Docs](https://github.com/oracle/graalpython/blob/master/docs/user/Native-Extensions.md)).
+- JPype1 implements its bridge as a CPython C extension, so GraalPy cannot reuse the binary wheels we rely on today and there is no upstream GraalPy build. This effectively blocks JPype1 on GraalPy.
+
+## Pillow
+- Pillow ships native C extension modules. GraalPy documents make clear that "Packages that use the native API must be built and installed with GraalPy, and the prebuilt wheels for CPython from pypi.org cannot be used." ([GraalPy Native Extensions Docs](https://github.com/oracle/graalpython/blob/master/docs/user/Native-Extensions.md)).
+- As long as a GraalPy-compatible wheel is not provided, Pillow must be rebuilt on every target system when using GraalPy's pip.
+
+## Pytest
+- Pytest is a pure-Python package and does not depend on CPython-only extensions, so it is expected to run on GraalPy without rebuilds.


### PR DESCRIPTION
## Summary
- document GraalPy migration guidance for remaining dependencies in a planning-only folder
- add a donotimplementyet agent guard to prevent accidental implementation of the planning documents

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc3b2b9c9c832789a5d219325e9e08