### PR TITLE
Enable mechanics-only mod runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ directly to Python developers.
 - Runtime bootstrap helpers (`modules.modbuilder.runtime_env`) that describe bundled Python packages and generate platform-specific activation commands.
 - Forward-looking roadmap documented in `futures.md`.
 - Built-in deck analytics helper that converts validation snapshots into tables and JSON artefacts for dashboards and plugins.
+- Mechanics-only mod support that activates the `experimental.graalpy_rule_weaver`
+  engine through `ModProject.enable_mechanics_runtime()` so rule packs can ship
+  without creating new characters or decks.
 
 ## Getting started
 

--- a/futures.md
+++ b/futures.md
@@ -205,3 +205,8 @@
   language/accent.  Document how directors select packs via
   `director.use_voice_pack("mentors/en_gb")` and expose the registration
   points through `PLUGIN_MANAGER` for tooling dashboards.
+- [todo] **Rule weaver script manifest verification** – Extend the new mechanics
+  runtime helpers with a `ProjectLayout` inspection pass that scans registered
+  script paths/resources, validates JSON/YAML structure ahead of bundling, and
+  publishes a manifest to `PLUGIN_MANAGER` so CI pipelines can diff mechanic
+  packs for unexpected mutations.

--- a/modules/basemod_wrapper/experimental/graalpy_rule_weaver.py
+++ b/modules/basemod_wrapper/experimental/graalpy_rule_weaver.py
@@ -523,6 +523,10 @@ class RuleWeaverEngine:
         for identifier in list(self._activations):
             self.deactivate_mutation(identifier)
 
+    def clear_blueprint_providers(self) -> None:
+        with self._lock:
+            self.blueprint_providers.clear()
+
     # ------------------------------------------------------------------
     @property
     def registered_mutations(self) -> Mapping[str, MechanicMutation]:
@@ -563,6 +567,7 @@ def activate() -> RuleWeaverEngine:
 
 def deactivate() -> None:
     _ENGINE.deactivate_all()
+    _ENGINE.clear_blueprint_providers()
     _refresh_plugin_exports()
 
 

--- a/tests/test_project_mechanics.py
+++ b/tests/test_project_mechanics.py
@@ -1,0 +1,178 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from modules.basemod_wrapper import experimental
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.project import ModProject
+from plugins import PLUGIN_MANAGER
+
+from tests.test_graalpy_rule_weaver import _write_fake_graalpy
+
+
+def _restore_environment(snapshot):
+    for key, value in snapshot.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_mechanics_only_project_runtime(tmp_path: Path, use_real_dependencies: bool) -> None:
+    project = ModProject("buddy_mechanics", "Buddy Mechanics", "Buddy", "Runtime tweaks")
+
+    blueprint = SimpleCardBlueprint(
+        identifier="BuddyMechanic",
+        title="Buddy Mechanic",
+        description="Gain {block} Block.",
+        cost=1,
+        card_type="skill",
+        target="self",
+        rarity="common",
+        effect="block",
+        value=5,
+        upgrade_value=2,
+        keywords=("artifact",),
+        keyword_values={"artifact": 1},
+    )
+
+    project.register_mechanic_blueprint_provider(lambda: (blueprint,))
+
+    path_script = tmp_path / "buddy_rules.json"
+    path_script.write_text(
+        json.dumps(
+            {
+                "mutations": [
+                    {
+                        "id": "buddy_cost_rework",
+                        "operations": [
+                            {
+                                "type": "adjust_card",
+                                "card_id": "BuddyMechanic",
+                                "cost": 0,
+                                "secondary_value": 3,
+                            },
+                            {
+                                "type": "set_description",
+                                "card_id": "BuddyMechanic",
+                                "description": "Gain {block} Block and refund energy.",
+                            },
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf8",
+    )
+
+    project.register_mechanic_script_path(lambda path=path_script: path)
+
+    package_root = tmp_path / "buddy_runtime_pkg"
+    package_root.mkdir()
+    (package_root / "__init__.py").write_text("", encoding="utf8")
+    resource_script = package_root / "resource_rules.json"
+    resource_script.write_text(
+        json.dumps(
+            {
+                "mutations": [
+                    {
+                        "id": "buddy_keyword_attachments",
+                        "operations": [
+                            {
+                                "type": "add_keyword",
+                                "card_id": "BuddyMechanic",
+                                "keyword": "exhaustive",
+                                "amount": 2,
+                                "card_uses": 2,
+                                "card_uses_upgrade": 1,
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf8",
+    )
+
+    original_sys_path = list(sys.path)
+    sys.path.insert(0, str(tmp_path))
+    project.register_mechanic_script_resource("buddy_runtime_pkg", "resource_rules.json")
+
+    from modules.basemod_wrapper.experimental import graalpy_rule_weaver as rule_weaver
+
+    def _apply(context: rule_weaver.RuleWeaverContext) -> rule_weaver.MechanicActivation:
+        revert = context.adjust_card_values("BuddyMechanic", value=9)
+        return rule_weaver.MechanicActivation(
+            identifier="buddy_value_increase",
+            revert_callbacks=(revert,),
+        )
+
+    mutation = rule_weaver.MechanicMutation(
+        identifier="buddy_value_increase",
+        description="Raise Buddy Mechanic block while testing mechanics-only builds.",
+        apply=_apply,
+        priority=50,
+    )
+
+    project.register_mechanic_mutation(mutation, activate=True)
+
+    env_keys = (
+        "STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE",
+        "STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE_EXECUTABLE",
+        "GRAALPY_HOME",
+    )
+    env_snapshot = {key: os.environ.get(key) for key in env_keys}
+
+    try:
+        if use_real_dependencies:
+            graalpy_home = tmp_path / "graalpy_home"
+            (graalpy_home / "bin").mkdir(parents=True)
+            fake_exe = graalpy_home / "bin" / "graalpy"
+            _write_fake_graalpy(fake_exe)
+            os.environ["GRAALPY_HOME"] = str(graalpy_home)
+            os.environ.pop("STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE", None)
+            os.environ.pop("STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE_EXECUTABLE", None)
+        else:
+            simulator = tmp_path / "simulator"
+            simulator.write_text("#!/usr/bin/env python3\nimport sys; sys.exit(0)\n", encoding="utf8")
+            simulator.chmod(0o755)
+            os.environ["STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE"] = "1"
+            os.environ["STSMODDERGUI_GRAALPY_RUNTIME_SIMULATE_EXECUTABLE"] = str(simulator)
+            os.environ.pop("GRAALPY_HOME", None)
+
+        engine = project.enable_mechanics_runtime()
+        assert experimental.is_active("graalpy_rule_weaver")
+        assert engine is rule_weaver.get_engine()
+
+        assert blueprint.cost == 0
+        assert blueprint.value == 9
+        assert "exhaustive" in blueprint.keywords
+        assert blueprint.card_uses == 2
+        assert blueprint.card_uses_upgrade == 1
+        assert "refund" not in blueprint.keywords
+
+        exposed_key = f"mod_project:{project.mod_id}:mechanics_runtime"
+        exposed_payload = PLUGIN_MANAGER.exposed[exposed_key]
+        resolved_script = str(path_script.resolve())
+        assert resolved_script in exposed_payload["scripts"]
+        assert mutation.identifier in exposed_payload["mutations"]
+
+        project.enable_mechanics_runtime()
+        assert blueprint.cost == 0
+        assert blueprint.value == 9
+        assert blueprint.card_uses == 2
+        assert blueprint.keywords.count("exhaustive") == 1
+
+    finally:
+        _restore_environment(env_snapshot)
+        sys.path[:] = original_sys_path
+        sys.modules.pop("buddy_runtime_pkg", None)
+        for module_name in ("graalpy_rule_weaver", "graalpy_runtime"):
+            try:
+                experimental.off(module_name)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- add a mechanics runtime plan to ModProject so projects can register rule-weaver blueprint providers, scripts, mutations and hooks
- expose a new enable_mechanics_runtime flow in the scaffolded project template and update the documentation to describe mechanics-only builds
- clear experimental rule-weaver blueprint providers on deactivation and cover the workflow with a mechanics-only regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc1503bc8832788e768cce25d1d9a