### PR TITLE
Add adaptive deck evolver mechanics mod

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -63,6 +63,13 @@
   submodule, document its activation hooks, and surface an `experimental.on`
   example in the wrapper README so teams can trial features without forking
   the stable API.
+- [todo] **Adaptive evolver tuning console** – Ship a CLI and dashboard that
+  visualises the persistent adaptive deck profile, highlights mutation
+  rationales, and allows designers to export/import heuristic weights.
+  Usage: extend `mods.adaptive_deck_evolver.runtime` with an inspection API,
+  build a `python -m mods.adaptive_deck_evolver inspect` entrypoint that dumps
+  the current `PlayerProfile`, and document how plugins can subscribe to the
+  emitted telemetry to provide custom UIs.
 - [todo] **LimeWire decryption pipeline** – Build a Python implementation of
   the LimeWire content decrypter so that the encrypted jars downloaded during
   bundling can be unwrapped automatically. Usage: mirror the

--- a/mods/__init__.py
+++ b/mods/__init__.py
@@ -1,0 +1,26 @@
+"""Repository packaged mods and mechanic engines.
+
+The :mod:`mods` namespace collects gameplay systems that can be shipped as
+mechanics-only experiences.  Modules located here are designed to be entirely
+plugin-friendly: they expose their public API through the global
+:mod:`plugins` manager so downstream tooling can discover runtime objects,
+register extensions and inspect persistent state.
+
+The :class:`AdaptiveMechanicMod` defined in
+:mod:`mods.adaptive_deck_evolver.runtime` is exposed immediately for
+convenience.
+"""
+from __future__ import annotations
+
+from plugins import PLUGIN_MANAGER
+
+from .adaptive_deck_evolver.runtime import AdaptiveMechanicMod
+
+__all__ = ["AdaptiveMechanicMod"]
+
+# Provide friendly aliases for plugin consumers while keeping the automatic
+# lazy exposure active.  The plugin manager already exports every repository
+# module lazily, however exposing the high level factory under a predictable key
+# makes extension authoring substantially easier.
+PLUGIN_MANAGER.expose("adaptive_mechanic_mod_factory", AdaptiveMechanicMod)
+PLUGIN_MANAGER.expose_module("mods.adaptive_deck_evolver", alias="adaptive_deck_evolver")

--- a/mods/adaptive_deck_evolver/__init__.py
+++ b/mods/adaptive_deck_evolver/__init__.py
@@ -1,0 +1,57 @@
+"""Adaptive deck evolution mechanics package.
+
+This package implements a mechanics-only mod that observes every combat,
+constructs a richly detailed profile of the player's fighting style and evolves
+the registered deck after each victorious encounter.  The modules are split
+into clear layers so plugin authors can hook into any part of the pipeline:
+
+``models``
+    Data structures describing card profiles, combat events and evolution plans.
+``analysis``
+    Heuristic engine that interprets combat telemetry and builds play style
+    vectors.  The heuristic tracks card usage down to turn windows, energy
+    efficiency and synergy chains.
+``evolution``
+    Deck evolution engine that converts the heuristic output into concrete
+    blueprint adjustments and newly generated cards.
+``persistence``
+    Durable profile storage with schema upgrades and JSON round-tripping.
+``runtime``
+    High level façade that repositories and runtime hooks can use to record
+    fights and synchronise the resulting plan with :class:`ModProject`.
+
+The top-level package exposes the :class:`AdaptiveMechanicMod` runtime helper.
+"""
+from __future__ import annotations
+
+from .analysis import FightingStyleHeuristic
+from .evolution import DeckEvolutionEngine
+from .models import (
+    CardProfile,
+    CardUsageStats,
+    ComboStats,
+    CombatCardEvent,
+    CombatSessionRecord,
+    DeckMutation,
+    DeckMutationPlan,
+    StyleVector,
+)
+from .persistence import PlayerProfile, ProfilePersistence
+from .runtime import AdaptiveMechanicMod, CombatRecorder
+
+__all__ = [
+    "AdaptiveMechanicMod",
+    "CardProfile",
+    "CardUsageStats",
+    "ComboStats",
+    "CombatCardEvent",
+    "CombatRecorder",
+    "CombatSessionRecord",
+    "DeckEvolutionEngine",
+    "DeckMutation",
+    "DeckMutationPlan",
+    "FightingStyleHeuristic",
+    "PlayerProfile",
+    "ProfilePersistence",
+    "StyleVector",
+]

--- a/mods/adaptive_deck_evolver/analysis.py
+++ b/mods/adaptive_deck_evolver/analysis.py
@@ -1,0 +1,175 @@
+"""Heuristic that analyses combat telemetry and derives play style vectors."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .models import CardUsageStats, CombatCardEvent, CombatSessionRecord, StyleVector
+from .persistence import PlayerProfile
+
+
+STATUS_WEIGHTS: Mapping[str, float] = {
+    "vulnerable": 3.5,
+    "weak": 2.75,
+    "frail": 2.2,
+    "poison": 1.9,
+    "burn": 1.4,
+    "bleed": 2.1,
+    "strength": -3.0,
+    "dexterity": -2.8,
+    "artifact": -1.5,
+    "focus": -2.5,
+    "draw": 1.25,
+    "energy": 1.8,
+    "retain": 0.9,
+    "platedarmor": 1.7,
+    "metallicize": 1.4,
+    "clarity": 1.1,
+    "slow": 1.6,
+    "lockon": 1.8,
+    "mark": 1.5,
+}
+
+
+class FightingStyleHeuristic:
+    """Interpret combat logs and produce detailed fighting style analytics."""
+
+    def __init__(self, profile: PlayerProfile) -> None:
+        self.profile = profile
+        self._latest_style: Optional[StyleVector] = None
+        if profile.style_history:
+            self._latest_style = profile.style_history[-1]
+
+    # ------------------------------------------------------------------
+    def ingest_combat(self, combat: CombatSessionRecord) -> StyleVector:
+        """Update the profile using ``combat`` and return the new style vector."""
+
+        events = combat.card_events
+        for index, event in enumerate(events):
+            follower = events[index + 1].card_id if index + 1 < len(events) else None
+            predecessor = events[index - 1].card_id if index > 0 else None
+            score = event.effectiveness(STATUS_WEIGHTS)
+            stats = self.profile.card_usage(event.card_id)
+            stats.record_event(
+                event,
+                score=score,
+                victory=combat.victory,
+                follower=follower,
+                predecessor=predecessor,
+            )
+        self._record_combos(events, combat.victory)
+        style_vector = self._compute_style_vector()
+        self.profile.update_from_combat(combat, style_vector=style_vector)
+        self._latest_style = style_vector
+        return style_vector
+
+    # ------------------------------------------------------------------
+    def score_card(self, card_id: str) -> float:
+        stats = self.profile.card_stats.get(card_id)
+        if not stats or not stats.plays:
+            return 0.0
+        base_score = stats.average_score()
+        synergy_bonus = 0.0
+        for follower, count in stats.combo_followers.items():
+            follower_stats = self.profile.card_stats.get(follower)
+            if not follower_stats or not follower_stats.plays:
+                continue
+            synergy_bonus += follower_stats.average_score() * (count / max(stats.plays, 1)) * 0.2
+        return base_score + synergy_bonus
+
+    def rank_cards(self, *, limit: int = 10) -> List[Tuple[str, float]]:
+        scored = [(card_id, self.score_card(card_id)) for card_id in self.profile.card_stats]
+        scored.sort(key=lambda item: item[1], reverse=True)
+        return scored[:limit]
+
+    def top_combos(self, *, limit: int = 5, minimum_plays: int = 2) -> List[Tuple[Tuple[str, ...], float]]:
+        combos: List[Tuple[Tuple[str, ...], float]] = []
+        for key, stats in self.profile.combo_stats.items():
+            if stats.plays < minimum_plays:
+                continue
+            combos.append((stats.key, stats.average_score()))
+        combos.sort(key=lambda item: item[1], reverse=True)
+        return combos[:limit]
+
+    @property
+    def style_vector(self) -> Optional[StyleVector]:
+        return self._latest_style
+
+    # ------------------------------------------------------------------
+    def _record_combos(self, events: Sequence[CombatCardEvent], victory: bool) -> None:
+        if len(events) < 2:
+            return
+        for length in (2, 3):
+            if len(events) < length:
+                continue
+            for index in range(len(events) - length + 1):
+                window = events[index : index + length]
+                key = tuple(event.card_id for event in window)
+                stats = self.profile.combo_usage(key)
+                stats.record(window, victory=victory, status_weights=STATUS_WEIGHTS)
+
+    def _compute_style_vector(self) -> StyleVector:
+        fights = max(self.profile.fights_recorded, 1)
+        damage_rate = self.profile.damage_dealt_total / fights
+        block_rate = self.profile.block_gained_total / fights
+        control_rate = self.profile.status_value_total / fights
+        energy_spent = max(self.profile.energy_spent_total, 1.0)
+        energy_efficiency = 1.0 - (self.profile.energy_wasted_total / energy_spent)
+        energy_efficiency = max(min(energy_efficiency, 1.0), -1.0)
+
+        combo_candidates = [(stats.key, stats.average_score(), stats.plays) for stats in self.profile.combo_stats.values() if stats.plays]
+        dominant_combo: Tuple[str, ...] = ()
+        combo_score = 0.0
+        if combo_candidates:
+            combo_candidates.sort(key=lambda item: (item[1], item[2]), reverse=True)
+            dominant_combo, combo_score, _ = combo_candidates[0]
+
+        draw_bias = self._compute_draw_bias()
+        preferred_turn_window = self._resolve_turn_window()
+
+        aggression = damage_rate + (combo_score * 0.2)
+        defense = block_rate + (draw_bias * 0.15)
+        control = control_rate + (combo_score * 0.1)
+        combo = combo_score + draw_bias * 0.05
+
+        summary_parts = [
+            f"Aggression {aggression:.2f}",
+            f"Defense {defense:.2f}",
+            f"Control {control:.2f}",
+            f"Combo {combo:.2f}",
+            f"Energy {energy_efficiency:.2f}",
+            f"Draw {draw_bias:.2f}",
+            f"Turns {preferred_turn_window}",
+        ]
+        summary = " | ".join(summary_parts)
+        return StyleVector(
+            aggression=aggression,
+            defense=defense,
+            control=control,
+            combo=combo,
+            energy_efficiency=energy_efficiency,
+            draw_bias=draw_bias,
+            preferred_turn_window=preferred_turn_window,
+            dominant_combo=dominant_combo,
+            summary=summary,
+        )
+
+    def _compute_draw_bias(self) -> float:
+        draw_events = 0
+        total_plays = 0
+        for stats in self.profile.card_stats.values():
+            draw_events += stats.draw_triggers
+            total_plays += stats.plays
+        if not total_plays:
+            return 0.0
+        return draw_events / total_plays
+
+    def _resolve_turn_window(self) -> str:
+        bucket_counter: MutableMapping[str, int] = Counter()
+        for stats in self.profile.card_stats.values():
+            for bucket, count in stats.turn_buckets.items():
+                bucket_counter[bucket] += count
+        if not bucket_counter:
+            return "unknown"
+        bucket, _ = bucket_counter.most_common(1)[0]
+        return bucket

--- a/mods/adaptive_deck_evolver/evolution.py
+++ b/mods/adaptive_deck_evolver/evolution.py
@@ -1,0 +1,275 @@
+"""Deck evolution engine that converts heuristic signals into mutations."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from .analysis import FightingStyleHeuristic
+from .models import (
+    CardProfile,
+    CardUsageStats,
+    ComboStats,
+    DeckMutation,
+    DeckMutationPlan,
+    KeywordAdjustment,
+    StyleVector,
+)
+from .persistence import PlayerProfile
+
+
+class DeckEvolutionEngine:
+    """Generate and apply deck evolution plans using combat heuristics."""
+
+    def __init__(self, profile: PlayerProfile, heuristic: FightingStyleHeuristic) -> None:
+        self.profile = profile
+        self.heuristic = heuristic
+
+    # ------------------------------------------------------------------
+    def plan_evolution(
+        self,
+        *,
+        style_vector: Optional[StyleVector] = None,
+    ) -> DeckMutationPlan:
+        style = style_vector or self.heuristic.style_vector
+        if style is None:
+            style = StyleVector(
+                aggression=0.0,
+                defense=0.0,
+                control=0.0,
+                combo=0.0,
+                energy_efficiency=0.0,
+                draw_bias=0.0,
+                preferred_turn_window="unknown",
+                dominant_combo=(),
+                summary="No data yet",
+            )
+        mutations = self._identify_card_mutations(style)
+        new_cards, unlockables = self._generate_new_cards(style)
+        notes = [
+            f"Dominant archetype: {style.dominant_archetype()}",
+            f"Energy efficiency: {style.energy_efficiency:.2f}",
+            f"Combo focus: {style.combo:.2f}",
+        ]
+        plan = DeckMutationPlan(
+            mutations=tuple(mutations),
+            new_cards=tuple(new_cards),
+            unlockables=tuple(unlockables),
+            style_vector=style,
+            notes=tuple(notes),
+        )
+        return plan
+
+    def apply(self, plan: DeckMutationPlan) -> None:
+        if plan.is_empty():
+            return
+        for mutation in plan.mutations:
+            card = self.profile.deck.get(mutation.card_id)
+            if not card:
+                continue
+            card.apply_mutation(mutation)
+            self.profile.deck[card.identifier] = card
+        for card in plan.new_cards:
+            self.profile.register_card_profile(card)
+        for card in plan.unlockables:
+            self.profile.register_unlockable(card)
+        self.profile.record_mutation_plan(plan)
+
+    # ------------------------------------------------------------------
+    def _identify_card_mutations(self, style: StyleVector) -> List[DeckMutation]:
+        archetype = style.dominant_archetype()
+        mutations: List[DeckMutation] = []
+        mutated_ids: set[str] = set()
+        energy_pressure = style.energy_efficiency < 0.3
+        card_stats = sorted(
+            (stats for stats in self.profile.card_stats.values() if stats.plays >= 3),
+            key=lambda item: item.plays,
+            reverse=True,
+        )
+        for stats in card_stats:
+            card = self.profile.deck.get(stats.card_id)
+            if not card:
+                continue
+            avg_score = stats.average_score()
+            notes: List[str] = []
+            new_value: Optional[int] = None
+            new_upgrade: Optional[int] = None
+            new_cost: Optional[int] = None
+            new_secondary: Optional[int] = None
+            new_secondary_upgrade: Optional[int] = None
+            keyword_adjustments: List[KeywordAdjustment] = []
+            if avg_score < -0.45:
+                if archetype == "aggressive":
+                    delta = max(2, int(abs(avg_score) * 1.8))
+                    new_value = card.value + delta
+                    new_upgrade = card.upgrade_value + max(1, delta // 2)
+                    notes.append(f"Aggressive boost: +{delta} base damage")
+                elif archetype == "defensive":
+                    delta = max(3, int(abs(avg_score) * 2.5))
+                    new_secondary = (card.secondary_value or card.value) + delta
+                    new_secondary_upgrade = card.secondary_upgrade + max(1, delta // 2)
+                    notes.append(f"Defensive reinforcement: +{delta} block/secondary value")
+                elif archetype == "control":
+                    keyword_adjustments.append(KeywordAdjustment(keyword="weak", amount=1, upgrade=1))
+                    new_upgrade = card.upgrade_value + 1
+                    notes.append("Control focus: added Weak keyword")
+                else:
+                    delta = max(2, int(abs(avg_score) * 1.5))
+                    new_value = card.value + delta
+                    new_upgrade = card.upgrade_value + max(1, delta // 2)
+                    notes.append(f"General boost: +{delta} value")
+            if energy_pressure and card.cost > 1:
+                new_cost = max(card.cost - 1, 0)
+                notes.append("Reduced cost to relieve energy pressure")
+            if not notes:
+                continue
+            mutation = DeckMutation(
+                card_id=card.identifier,
+                new_value=new_value,
+                new_upgrade_value=new_upgrade,
+                new_cost=new_cost,
+                new_secondary_value=new_secondary,
+                new_secondary_upgrade=new_secondary_upgrade,
+                keyword_adjustments=tuple(keyword_adjustments),
+                role=archetype,
+                notes=tuple(notes),
+                metadata={
+                    "average_score": avg_score,
+                    "plays": stats.plays,
+                    "reason": "underperforming_card",
+                },
+            )
+            mutations.append(mutation)
+            mutated_ids.add(card.identifier)
+        # Enhance standout cards for mastery
+        top_cards = self.heuristic.rank_cards(limit=5)
+        for card_id, score in top_cards:
+            if score <= 1.0:
+                continue
+            if card_id in mutated_ids:
+                continue
+            card = self.profile.deck.get(card_id)
+            if not card:
+                continue
+            upgrade_boost = max(1, int(score // 1.5))
+            mutation = DeckMutation(
+                card_id=card_id,
+                new_upgrade_value=card.upgrade_value + upgrade_boost,
+                notes=(f"Rewarding mastery: +{upgrade_boost} upgrade value",),
+                role=archetype,
+                metadata={"reason": "top_performer", "score": score},
+            )
+            mutations.append(mutation)
+        return mutations
+
+    def _generate_new_cards(self, style: StyleVector) -> Tuple[List[CardProfile], List[CardProfile]]:
+        combos = self.heuristic.top_combos(limit=4, minimum_plays=3)
+        if not combos:
+            return ([], [])
+        archetype = style.dominant_archetype()
+        existing_tokens = {
+            card.generated_by
+            for card in list(self.profile.deck.values()) + list(self.profile.unlockables.values())
+            if card.generated_by
+        }
+        deck_cards: List[CardProfile] = []
+        unlockables: List[CardProfile] = []
+        for combo, score in combos:
+            token = f"combo:{'->'.join(combo)}"
+            if token in existing_tokens:
+                continue
+            stats = self.profile.combo_stats.get("::".join(combo))
+            if not stats:
+                continue
+            card_profile = self._build_card_from_combo(combo, stats, style, archetype, token)
+            if not card_profile:
+                continue
+            if score > 4.5:
+                deck_cards.append(card_profile)
+            else:
+                unlockables.append(card_profile)
+            existing_tokens.add(token)
+            if len(deck_cards) + len(unlockables) >= 3:
+                break
+        return (deck_cards, unlockables)
+
+    def _build_card_from_combo(
+        self,
+        combo: Tuple[str, ...],
+        stats: ComboStats,
+        style: StyleVector,
+        archetype: str,
+        token: str,
+    ) -> Optional[CardProfile]:
+        energy_cost = max(0, round(stats.energy_cost()))
+        damage = int(max(stats.damage_total / max(stats.plays, 1), 0))
+        block = int(max(stats.block_total / max(stats.plays, 1), 0))
+        if damage == 0 and block == 0:
+            damage = 6
+        if archetype == "defensive" and block < damage:
+            block = max(block, damage // 2)
+        if archetype == "control" and damage < 4:
+            damage = 4
+        rarity = "UNCOMMON"
+        if stats.average_score() > 7:
+            rarity = "RARE"
+        elif stats.average_score() < 3:
+            rarity = "COMMON"
+        description = self._compose_description(archetype, damage, block, stats, combo)
+        keywords: List[str] = []
+        keyword_values: Dict[str, int] = {}
+        keyword_upgrades: Dict[str, int] = {}
+        if archetype == "control":
+            keywords.append("weak")
+            keyword_values["weak"] = 1
+            keyword_upgrades["weak"] = 1
+        if archetype == "defensive" and block > 0:
+            keywords.append("retain")
+        prefix = "combo"
+        identifier = self.profile.allocate_card_identifier(prefix=prefix)
+        card_type = "ATTACK" if damage >= block else "SKILL"
+        effect = None if card_type == "ATTACK" else "block"
+        secondary_value = block if card_type == "SKILL" else None
+        secondary_upgrade = max(1, block // 3) if secondary_value else 0
+        upgrade_value = max(1, damage // 3)
+        card = CardProfile(
+            identifier=identifier,
+            title=f"{combo[0].title()} Synergy",
+            description=description,
+            upgrade_description=f"Improved synergy from {' and '.join(combo)}",
+            card_type=card_type,
+            target="ENEMY" if card_type == "ATTACK" else "SELF",
+            rarity=rarity,
+            cost=energy_cost,
+            value=max(damage, 4),
+            upgrade_value=max(upgrade_value, 2),
+            effect=effect,
+            secondary_value=secondary_value,
+            secondary_upgrade=secondary_upgrade,
+            keywords=tuple(keywords),
+            keyword_values=keyword_values,
+            keyword_upgrades=keyword_upgrades,
+            role=archetype,
+            generated_by=token,
+            notes=(f"Generated from combo {' -> '.join(combo)}",),
+        )
+        return card
+
+    def _compose_description(
+        self,
+        archetype: str,
+        damage: int,
+        block: int,
+        stats: ComboStats,
+        combo: Tuple[str, ...],
+    ) -> str:
+        parts = [f"Inspired by {' -> '.join(combo)}."]
+        if archetype == "aggressive":
+            parts.append(f"Deal {max(damage, 6)} damage twice.")
+        elif archetype == "defensive":
+            parts.append(f"Gain {max(block, 6)} Block and Retain this turn.")
+        elif archetype == "control":
+            parts.append(f"Apply 1 Weak and deal {max(damage, 4)} damage.")
+        else:
+            parts.append(f"Deal {max(damage, 6)} damage and gain {max(block, 4)} Block.")
+        if stats.average_turn:
+            parts.append(f"Optimised for turn {stats.average_turn:.1f}.")
+        return " ".join(parts)

--- a/mods/adaptive_deck_evolver/models.py
+++ b/mods/adaptive_deck_evolver/models.py
@@ -1,0 +1,670 @@
+"""Data structures for the adaptive deck evolver mechanics."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+
+TURN_BUCKETS: Tuple[Tuple[int, int], ...] = ((1, 2), (3, 5), (6, 9), (10, 99))
+TURN_BUCKET_NAMES: Tuple[str, ...] = ("early", "mid", "late", "endurance")
+
+
+@dataclass(slots=True)
+class CombatCardEvent:
+    """Represents a single card play recorded during combat."""
+
+    card_id: str
+    turn: int
+    energy_before: float
+    energy_spent: float
+    energy_remaining: float
+    damage_dealt: float
+    block_gained: float
+    player_hp_change: float
+    enemy_hp_change: float
+    status_effects: Mapping[str, Mapping[str, float]] = field(default_factory=dict)
+    cards_drawn: int = 0
+    cards_discarded: int = 0
+    exhausted: bool = False
+    retained: bool = False
+    energy_generated: float = 0.0
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+    timestamp: float = field(default_factory=lambda: datetime.now(timezone.utc).timestamp())
+
+    def effectiveness(self, status_weights: Mapping[str, float]) -> float:
+        """Return a heuristic score describing how successful the play was."""
+
+        enemy_effects = self.status_effects.get("enemy", {})
+        player_effects = self.status_effects.get("player", {})
+        neutral_effects = self.status_effects.get("environment", {})
+        status_score = 0.0
+        for status, amount in enemy_effects.items():
+            weight = status_weights.get(status.lower(), 1.0)
+            status_score += weight * float(amount)
+        for status, amount in player_effects.items():
+            weight = status_weights.get(status.lower(), 1.0)
+            status_score -= abs(weight) * abs(float(amount))
+        for status, amount in neutral_effects.items():
+            weight = status_weights.get(status.lower(), 0.5)
+            status_score += weight * float(amount)
+
+        damage_score = float(self.damage_dealt)
+        block_score = float(self.block_gained) * 0.65
+        card_flow = (self.cards_drawn - self.cards_discarded) * 0.4
+        energy_delta = (self.energy_generated - self.energy_spent) * 0.35
+        energy_waste_penalty = max(self.energy_remaining, 0.0) * 0.15
+        hp_penalty = 0.0
+        if self.player_hp_change < 0:
+            hp_penalty += abs(self.player_hp_change) * 1.4
+        if self.enemy_hp_change > 0:
+            hp_penalty += abs(self.enemy_hp_change) * 0.6
+        combo_bonus = 0.35 if self.retained else 0.0
+        exhaust_bonus = 0.55 if self.exhausted else 0.0
+
+        score = (
+            damage_score
+            + block_score
+            + status_score
+            + card_flow
+            + energy_delta
+            + combo_bonus
+            + exhaust_bonus
+            - energy_waste_penalty
+            - hp_penalty
+        )
+        return score
+
+    def turn_bucket(self) -> str:
+        for (start, end), name in zip(TURN_BUCKETS, TURN_BUCKET_NAMES):
+            if start <= self.turn <= end:
+                return name
+        return TURN_BUCKET_NAMES[-1]
+
+
+@dataclass(slots=True)
+class CardUsageStats:
+    """Aggregated card usage metrics across all recorded combats."""
+
+    card_id: str
+    plays: int = 0
+    victories: int = 0
+    defeats: int = 0
+    total_score: float = 0.0
+    positive_score: float = 0.0
+    negative_score: float = 0.0
+    damage_total: float = 0.0
+    block_total: float = 0.0
+    status_total: float = 0.0
+    energy_spent: float = 0.0
+    energy_generated: float = 0.0
+    energy_wasted: float = 0.0
+    average_energy_before: float = 0.0
+    turn_buckets: MutableMapping[str, int] = field(default_factory=lambda: {bucket: 0 for bucket in TURN_BUCKET_NAMES})
+    combo_followers: MutableMapping[str, int] = field(default_factory=dict)
+    combo_predecessors: MutableMapping[str, int] = field(default_factory=dict)
+    draw_triggers: int = 0
+    exhaust_triggers: int = 0
+    retention_triggers: int = 0
+    last_played: float = 0.0
+
+    def record_event(
+        self,
+        event: CombatCardEvent,
+        *,
+        score: float,
+        victory: bool,
+        follower: Optional[str] = None,
+        predecessor: Optional[str] = None,
+    ) -> None:
+        self.plays += 1
+        self.total_score += score
+        if score >= 0:
+            self.positive_score += score
+        else:
+            self.negative_score += score
+        if victory:
+            self.victories += 1
+        else:
+            self.defeats += 1
+        self.damage_total += float(event.damage_dealt)
+        self.block_total += float(event.block_gained)
+        enemy_effects = event.status_effects.get("enemy", {})
+        player_effects = event.status_effects.get("player", {})
+        self.status_total += sum(float(amount) for amount in enemy_effects.values())
+        self.status_total -= sum(abs(float(amount)) for amount in player_effects.values())
+        self.energy_spent += float(event.energy_spent)
+        self.energy_generated += float(event.energy_generated)
+        self.energy_wasted += max(event.energy_remaining, 0.0)
+        self.average_energy_before += float(event.energy_before)
+        self.turn_buckets[event.turn_bucket()] = self.turn_buckets.get(event.turn_bucket(), 0) + 1
+        self.draw_triggers += int(max(event.cards_drawn, 0))
+        self.exhaust_triggers += 1 if event.exhausted else 0
+        self.retention_triggers += 1 if event.retained else 0
+        self.last_played = max(self.last_played, event.timestamp)
+        if follower:
+            self.combo_followers[follower] = self.combo_followers.get(follower, 0) + 1
+        if predecessor:
+            self.combo_predecessors[predecessor] = self.combo_predecessors.get(predecessor, 0) + 1
+
+    def average_score(self) -> float:
+        if not self.plays:
+            return 0.0
+        return self.total_score / self.plays
+
+    def energy_efficiency(self) -> float:
+        spent = self.energy_spent or 1.0
+        return max(min((self.energy_generated + (self.energy_spent - self.energy_wasted)) / spent, 2.0), -2.0)
+
+    def preferred_turn_bucket(self) -> str:
+        if not self.plays:
+            return "unknown"
+        bucket, _ = max(self.turn_buckets.items(), key=lambda item: item[1])
+        return bucket
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "card_id": self.card_id,
+            "plays": self.plays,
+            "victories": self.victories,
+            "defeats": self.defeats,
+            "total_score": self.total_score,
+            "positive_score": self.positive_score,
+            "negative_score": self.negative_score,
+            "damage_total": self.damage_total,
+            "block_total": self.block_total,
+            "status_total": self.status_total,
+            "energy_spent": self.energy_spent,
+            "energy_generated": self.energy_generated,
+            "energy_wasted": self.energy_wasted,
+            "average_energy_before": self.average_energy_before,
+            "turn_buckets": dict(self.turn_buckets),
+            "combo_followers": dict(self.combo_followers),
+            "combo_predecessors": dict(self.combo_predecessors),
+            "draw_triggers": self.draw_triggers,
+            "exhaust_triggers": self.exhaust_triggers,
+            "retention_triggers": self.retention_triggers,
+            "last_played": self.last_played,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CardUsageStats":
+        instance = cls(card_id=str(payload["card_id"]))
+        instance.plays = int(payload.get("plays", 0))
+        instance.victories = int(payload.get("victories", 0))
+        instance.defeats = int(payload.get("defeats", 0))
+        instance.total_score = float(payload.get("total_score", 0.0))
+        instance.positive_score = float(payload.get("positive_score", 0.0))
+        instance.negative_score = float(payload.get("negative_score", 0.0))
+        instance.damage_total = float(payload.get("damage_total", 0.0))
+        instance.block_total = float(payload.get("block_total", 0.0))
+        instance.status_total = float(payload.get("status_total", 0.0))
+        instance.energy_spent = float(payload.get("energy_spent", 0.0))
+        instance.energy_generated = float(payload.get("energy_generated", 0.0))
+        instance.energy_wasted = float(payload.get("energy_wasted", 0.0))
+        instance.average_energy_before = float(payload.get("average_energy_before", 0.0))
+        buckets = payload.get("turn_buckets", {})
+        instance.turn_buckets = {bucket: int(buckets.get(bucket, 0)) for bucket in TURN_BUCKET_NAMES}
+        instance.combo_followers = {str(key): int(value) for key, value in (payload.get("combo_followers", {}) or {}).items()}
+        instance.combo_predecessors = {str(key): int(value) for key, value in (payload.get("combo_predecessors", {}) or {}).items()}
+        instance.draw_triggers = int(payload.get("draw_triggers", 0))
+        instance.exhaust_triggers = int(payload.get("exhaust_triggers", 0))
+        instance.retention_triggers = int(payload.get("retention_triggers", 0))
+        instance.last_played = float(payload.get("last_played", 0.0))
+        return instance
+
+
+@dataclass(slots=True)
+class ComboStats:
+    """Aggregated statistics for observed card combinations."""
+
+    key: Tuple[str, ...]
+    plays: int = 0
+    victories: int = 0
+    defeats: int = 0
+    total_score: float = 0.0
+    damage_total: float = 0.0
+    block_total: float = 0.0
+    energy_total: float = 0.0
+    average_turn: float = 0.0
+
+    def record(self, events: Sequence[CombatCardEvent], *, victory: bool, status_weights: Mapping[str, float]) -> None:
+        if not events:
+            return
+        self.plays += 1
+        if victory:
+            self.victories += 1
+        else:
+            self.defeats += 1
+        score = sum(event.effectiveness(status_weights) for event in events)
+        self.total_score += score
+        self.damage_total += sum(event.damage_dealt for event in events)
+        self.block_total += sum(event.block_gained for event in events)
+        self.energy_total += sum(event.energy_spent for event in events)
+        turn_average = sum(event.turn for event in events) / len(events)
+        self.average_turn = ((self.average_turn * (self.plays - 1)) + turn_average) / self.plays
+
+    def average_score(self) -> float:
+        if not self.plays:
+            return 0.0
+        return self.total_score / self.plays
+
+    def energy_cost(self) -> float:
+        if not self.plays:
+            return 0.0
+        return self.energy_total / self.plays
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "key": list(self.key),
+            "plays": self.plays,
+            "victories": self.victories,
+            "defeats": self.defeats,
+            "total_score": self.total_score,
+            "damage_total": self.damage_total,
+            "block_total": self.block_total,
+            "energy_total": self.energy_total,
+            "average_turn": self.average_turn,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "ComboStats":
+        instance = cls(tuple(str(part) for part in payload.get("key", ()) or ()))
+        instance.plays = int(payload.get("plays", 0))
+        instance.victories = int(payload.get("victories", 0))
+        instance.defeats = int(payload.get("defeats", 0))
+        instance.total_score = float(payload.get("total_score", 0.0))
+        instance.damage_total = float(payload.get("damage_total", 0.0))
+        instance.block_total = float(payload.get("block_total", 0.0))
+        instance.energy_total = float(payload.get("energy_total", 0.0))
+        instance.average_turn = float(payload.get("average_turn", 0.0))
+        return instance
+
+
+@dataclass(slots=True)
+class CombatSessionRecord:
+    """Snapshot describing a completed combat encounter."""
+
+    combat_id: str
+    enemy: str
+    floor: int
+    victory: bool
+    turn_count: int
+    player_hp_start: float
+    player_hp_end: float
+    card_events: Tuple[CombatCardEvent, ...]
+    relics: Tuple[str, ...] = ()
+    reward_cards: Tuple[str, ...] = ()
+    notes: Tuple[str, ...] = ()
+    timestamp: float = field(default_factory=lambda: datetime.now(timezone.utc).timestamp())
+
+    @property
+    def damage_taken(self) -> float:
+        return max(self.player_hp_start - self.player_hp_end, 0.0)
+
+    @property
+    def style_signature(self) -> Mapping[str, Any]:
+        return {
+            "enemy": self.enemy,
+            "floor": self.floor,
+            "turn_count": self.turn_count,
+            "relics": self.relics,
+            "reward_cards": self.reward_cards,
+        }
+
+
+@dataclass(slots=True)
+class StyleVector:
+    """Represents the aggregate fighting style detected for a profile."""
+
+    aggression: float
+    defense: float
+    control: float
+    combo: float
+    energy_efficiency: float
+    draw_bias: float
+    preferred_turn_window: str
+    dominant_combo: Tuple[str, ...]
+    summary: str
+
+    def dominant_archetype(self) -> str:
+        scores = {
+            "aggressive": self.aggression,
+            "defensive": self.defense,
+            "control": self.control,
+            "combo": self.combo,
+        }
+        archetype, _ = max(scores.items(), key=lambda item: item[1])
+        return archetype
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "aggression": self.aggression,
+            "defense": self.defense,
+            "control": self.control,
+            "combo": self.combo,
+            "energy_efficiency": self.energy_efficiency,
+            "draw_bias": self.draw_bias,
+            "preferred_turn_window": self.preferred_turn_window,
+            "dominant_combo": list(self.dominant_combo),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "StyleVector":
+        return cls(
+            aggression=float(payload.get("aggression", 0.0)),
+            defense=float(payload.get("defense", 0.0)),
+            control=float(payload.get("control", 0.0)),
+            combo=float(payload.get("combo", 0.0)),
+            energy_efficiency=float(payload.get("energy_efficiency", 0.0)),
+            draw_bias=float(payload.get("draw_bias", 0.0)),
+            preferred_turn_window=str(payload.get("preferred_turn_window", "unknown")),
+            dominant_combo=tuple(str(part) for part in payload.get("dominant_combo", ()) or ()),
+            summary=str(payload.get("summary", "")),
+        )
+
+
+@dataclass(slots=True)
+class CardProfile:
+    """Serializable mirror of :class:`SimpleCardBlueprint` with metadata."""
+
+    identifier: str
+    title: str
+    description: str
+    upgrade_description: Optional[str]
+    card_type: str
+    target: str
+    rarity: str
+    cost: int
+    value: int
+    upgrade_value: int
+    effect: Optional[str]
+    secondary_value: Optional[int]
+    secondary_upgrade: int
+    keywords: Tuple[str, ...] = field(default_factory=tuple)
+    keyword_values: Mapping[str, int] = field(default_factory=dict)
+    keyword_upgrades: Mapping[str, int] = field(default_factory=dict)
+    attack_effect: str = "SLASH_DIAGONAL"
+    card_uses: Optional[int] = None
+    card_uses_upgrade: int = 0
+    role: str = "generalist"
+    generated_by: Optional[str] = None
+    notes: Tuple[str, ...] = ()
+
+    def to_blueprint(self) -> SimpleCardBlueprint:
+        return SimpleCardBlueprint(
+            identifier=self.identifier,
+            title=self.title,
+            description=self.description,
+            cost=self.cost,
+            card_type=self.card_type,
+            target=self.target,
+            rarity=self.rarity,
+            value=self.value,
+            upgrade_value=self.upgrade_value,
+            effect=self.effect,
+            secondary_value=self.secondary_value,
+            secondary_upgrade=self.secondary_upgrade,
+            keywords=self.keywords,
+            keyword_values=dict(self.keyword_values),
+            keyword_upgrades=dict(self.keyword_upgrades),
+            attack_effect=self.attack_effect,
+            card_uses=self.card_uses,
+            card_uses_upgrade=self.card_uses_upgrade,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "identifier": self.identifier,
+            "title": self.title,
+            "description": self.description,
+            "upgrade_description": self.upgrade_description,
+            "card_type": self.card_type,
+            "target": self.target,
+            "rarity": self.rarity,
+            "cost": self.cost,
+            "value": self.value,
+            "upgrade_value": self.upgrade_value,
+            "effect": self.effect,
+            "secondary_value": self.secondary_value,
+            "secondary_upgrade": self.secondary_upgrade,
+            "keywords": list(self.keywords),
+            "keyword_values": dict(self.keyword_values),
+            "keyword_upgrades": dict(self.keyword_upgrades),
+            "attack_effect": self.attack_effect,
+            "card_uses": self.card_uses,
+            "card_uses_upgrade": self.card_uses_upgrade,
+            "role": self.role,
+            "generated_by": self.generated_by,
+            "notes": list(self.notes),
+        }
+
+    @classmethod
+    def from_blueprint(
+        cls,
+        blueprint: SimpleCardBlueprint,
+        *,
+        role: str = "generalist",
+        generated_by: Optional[str] = None,
+        notes: Sequence[str] = (),
+    ) -> "CardProfile":
+        upgrade_description = None
+        localisation = blueprint.localizations.get("eng") if blueprint.localizations else None
+        if localisation is not None:
+            upgrade_description = localisation.upgrade_description
+        return cls(
+            identifier=blueprint.identifier,
+            title=blueprint.title,
+            description=blueprint.description,
+            upgrade_description=upgrade_description,
+            card_type=blueprint.card_type,
+            target=blueprint.target,
+            rarity=blueprint.rarity,
+            cost=blueprint.cost,
+            value=blueprint.value,
+            upgrade_value=blueprint.upgrade_value,
+            effect=blueprint.effect,
+            secondary_value=blueprint.secondary_value,
+            secondary_upgrade=blueprint.secondary_upgrade,
+            keywords=tuple(blueprint.keywords),
+            keyword_values=dict(blueprint.keyword_values),
+            keyword_upgrades=dict(blueprint.keyword_upgrades),
+            attack_effect=blueprint.attack_effect,
+            card_uses=blueprint.card_uses,
+            card_uses_upgrade=blueprint.card_uses_upgrade,
+            role=role,
+            generated_by=generated_by,
+            notes=tuple(notes),
+        )
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CardProfile":
+        return cls(
+            identifier=str(payload["identifier"]),
+            title=str(payload.get("title", "")),
+            description=str(payload.get("description", "")),
+            upgrade_description=payload.get("upgrade_description"),
+            card_type=str(payload.get("card_type", "ATTACK")),
+            target=str(payload.get("target", "ENEMY")),
+            rarity=str(payload.get("rarity", "COMMON")),
+            cost=int(payload.get("cost", 1)),
+            value=int(payload.get("value", 6)),
+            upgrade_value=int(payload.get("upgrade_value", 3)),
+            effect=payload.get("effect"),
+            secondary_value=payload.get("secondary_value"),
+            secondary_upgrade=int(payload.get("secondary_upgrade", 0)),
+            keywords=tuple(str(keyword) for keyword in payload.get("keywords", ()) or ()),
+            keyword_values={str(k): int(v) for k, v in (payload.get("keyword_values", {}) or {}).items()},
+            keyword_upgrades={str(k): int(v) for k, v in (payload.get("keyword_upgrades", {}) or {}).items()},
+            attack_effect=str(payload.get("attack_effect", "SLASH_DIAGONAL")),
+            card_uses=payload.get("card_uses"),
+            card_uses_upgrade=int(payload.get("card_uses_upgrade", 0)),
+            role=str(payload.get("role", "generalist")),
+            generated_by=payload.get("generated_by"),
+            notes=tuple(str(entry) for entry in payload.get("notes", ()) or ()),
+        )
+
+    def apply_mutation(self, mutation: "DeckMutation") -> None:
+        if mutation.new_value is not None:
+            self.value = int(mutation.new_value)
+        if mutation.new_upgrade_value is not None:
+            self.upgrade_value = int(mutation.new_upgrade_value)
+        if mutation.new_cost is not None:
+            self.cost = int(mutation.new_cost)
+        if mutation.new_secondary_value is not None:
+            self.secondary_value = int(mutation.new_secondary_value)
+        if mutation.new_secondary_upgrade is not None:
+            self.secondary_upgrade = int(mutation.new_secondary_upgrade)
+        if mutation.description is not None:
+            self.description = mutation.description
+        if mutation.upgrade_description is not None:
+            self.upgrade_description = mutation.upgrade_description
+        if mutation.role:
+            self.role = mutation.role
+        if mutation.keyword_adjustments:
+            keywords = set(self.keywords)
+            values = dict(self.keyword_values)
+            upgrades = dict(self.keyword_upgrades)
+            for adjustment in mutation.keyword_adjustments:
+                keywords.add(adjustment.keyword)
+                if adjustment.amount is not None:
+                    values[adjustment.keyword] = int(adjustment.amount)
+                if adjustment.upgrade is not None:
+                    upgrades[adjustment.keyword] = int(adjustment.upgrade)
+                if adjustment.card_uses is not None:
+                    self.card_uses = int(adjustment.card_uses)
+                if adjustment.card_uses_upgrade is not None:
+                    self.card_uses_upgrade = int(adjustment.card_uses_upgrade)
+            self.keywords = tuple(sorted(keywords))
+            self.keyword_values = values
+            self.keyword_upgrades = upgrades
+        if mutation.notes:
+            self.notes = tuple(sorted(set(self.notes) | set(mutation.notes)))
+
+
+@dataclass(slots=True)
+class KeywordAdjustment:
+    """Describes a keyword change to apply to a card."""
+
+    keyword: str
+    amount: Optional[int] = None
+    upgrade: Optional[int] = None
+    card_uses: Optional[int] = None
+    card_uses_upgrade: Optional[int] = None
+
+
+@dataclass(slots=True)
+class DeckMutation:
+    """Represents a targeted modification to an existing card."""
+
+    card_id: str
+    new_value: Optional[int] = None
+    new_upgrade_value: Optional[int] = None
+    new_cost: Optional[int] = None
+    new_secondary_value: Optional[int] = None
+    new_secondary_upgrade: Optional[int] = None
+    description: Optional[str] = None
+    upgrade_description: Optional[str] = None
+    keyword_adjustments: Tuple[KeywordAdjustment, ...] = ()
+    role: str = "generalist"
+    notes: Tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "card_id": self.card_id,
+            "new_value": self.new_value,
+            "new_upgrade_value": self.new_upgrade_value,
+            "new_cost": self.new_cost,
+            "new_secondary_value": self.new_secondary_value,
+            "new_secondary_upgrade": self.new_secondary_upgrade,
+            "description": self.description,
+            "upgrade_description": self.upgrade_description,
+            "keyword_adjustments": [
+                {
+                    "keyword": adjustment.keyword,
+                    "amount": adjustment.amount,
+                    "upgrade": adjustment.upgrade,
+                    "card_uses": adjustment.card_uses,
+                    "card_uses_upgrade": adjustment.card_uses_upgrade,
+                }
+                for adjustment in self.keyword_adjustments
+            ],
+            "role": self.role,
+            "notes": list(self.notes),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DeckMutation":
+        adjustments = []
+        for entry in payload.get("keyword_adjustments", ()) or ():
+            adjustments.append(
+                KeywordAdjustment(
+                    keyword=str(entry.get("keyword", "")),
+                    amount=entry.get("amount"),
+                    upgrade=entry.get("upgrade"),
+                    card_uses=entry.get("card_uses"),
+                    card_uses_upgrade=entry.get("card_uses_upgrade"),
+                )
+            )
+        return cls(
+            card_id=str(payload["card_id"]),
+            new_value=payload.get("new_value"),
+            new_upgrade_value=payload.get("new_upgrade_value"),
+            new_cost=payload.get("new_cost"),
+            new_secondary_value=payload.get("new_secondary_value"),
+            new_secondary_upgrade=payload.get("new_secondary_upgrade"),
+            description=payload.get("description"),
+            upgrade_description=payload.get("upgrade_description"),
+            keyword_adjustments=tuple(adjustments),
+            role=str(payload.get("role", "generalist")),
+            notes=tuple(str(entry) for entry in payload.get("notes", ()) or ()),
+            metadata=payload.get("metadata", {}),
+        )
+
+
+@dataclass(slots=True)
+class DeckMutationPlan:
+    """Aggregates deck mutations and generated cards for a combat cycle."""
+
+    mutations: Tuple[DeckMutation, ...] = ()
+    new_cards: Tuple[CardProfile, ...] = ()
+    unlockables: Tuple[CardProfile, ...] = ()
+    style_vector: Optional[StyleVector] = None
+    notes: Tuple[str, ...] = ()
+    timestamp: float = field(default_factory=lambda: datetime.now(timezone.utc).timestamp())
+    source_combat: Optional[str] = None
+
+    def is_empty(self) -> bool:
+        return not self.mutations and not self.new_cards and not self.unlockables
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mutations": [mutation.to_dict() for mutation in self.mutations],
+            "new_cards": [card.to_dict() for card in self.new_cards],
+            "unlockables": [card.to_dict() for card in self.unlockables],
+            "style_vector": self.style_vector.to_dict() if self.style_vector else None,
+            "notes": list(self.notes),
+            "timestamp": self.timestamp,
+            "source_combat": self.source_combat,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DeckMutationPlan":
+        mutations = [DeckMutation.from_dict(entry) for entry in payload.get("mutations", ()) or ()]
+        new_cards = [CardProfile.from_dict(entry) for entry in payload.get("new_cards", ()) or ()]
+        unlockables = [CardProfile.from_dict(entry) for entry in payload.get("unlockables", ()) or ()]
+        style_vector_payload = payload.get("style_vector")
+        style_vector = StyleVector.from_dict(style_vector_payload) if style_vector_payload else None
+        return cls(
+            mutations=tuple(mutations),
+            new_cards=tuple(new_cards),
+            unlockables=tuple(unlockables),
+            style_vector=style_vector,
+            notes=tuple(str(entry) for entry in payload.get("notes", ()) or ()),
+            timestamp=float(payload.get("timestamp", datetime.utcnow().timestamp())),
+            source_combat=payload.get("source_combat"),
+        )

--- a/mods/adaptive_deck_evolver/persistence.py
+++ b/mods/adaptive_deck_evolver/persistence.py
@@ -1,0 +1,175 @@
+"""Persistent profile storage for the adaptive deck evolver."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Sequence
+
+from .models import (
+    CardProfile,
+    CardUsageStats,
+    ComboStats,
+    CombatSessionRecord,
+    DeckMutationPlan,
+    StyleVector,
+)
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(slots=True)
+class PlayerProfile:
+    """Stores aggregated analytics and deck state across runs."""
+
+    mod_id: str
+    schema_version: int = SCHEMA_VERSION
+    fights_recorded: int = 0
+    wins: int = 0
+    losses: int = 0
+    card_stats: MutableMapping[str, CardUsageStats] = field(default_factory=dict)
+    combo_stats: MutableMapping[str, ComboStats] = field(default_factory=dict)
+    deck: MutableMapping[str, CardProfile] = field(default_factory=dict)
+    unlockables: MutableMapping[str, CardProfile] = field(default_factory=dict)
+    style_history: Sequence[StyleVector] = field(default_factory=tuple)
+    energy_spent_total: float = 0.0
+    energy_wasted_total: float = 0.0
+    damage_dealt_total: float = 0.0
+    block_gained_total: float = 0.0
+    status_value_total: float = 0.0
+    generated_cards: int = 0
+    mutation_history: Sequence[Dict[str, Any]] = field(default_factory=tuple)
+
+    def card_usage(self, card_id: str) -> CardUsageStats:
+        card_id = str(card_id)
+        stats = self.card_stats.get(card_id)
+        if stats is None:
+            stats = CardUsageStats(card_id=card_id)
+            self.card_stats[card_id] = stats
+        return stats
+
+    def combo_usage(self, key: Sequence[str]) -> ComboStats:
+        identifier = tuple(key)
+        stats = self.combo_stats.get("::".join(identifier))
+        if stats is None:
+            stats = ComboStats(identifier)
+            self.combo_stats["::".join(identifier)] = stats
+        return stats
+
+    def register_card_profile(self, profile: CardProfile) -> None:
+        self.deck[profile.identifier] = profile
+
+    def register_unlockable(self, profile: CardProfile) -> None:
+        self.unlockables[profile.identifier] = profile
+
+    def update_from_combat(self, combat: CombatSessionRecord, *, style_vector: StyleVector) -> None:
+        self.fights_recorded += 1
+        if combat.victory:
+            self.wins += 1
+        else:
+            self.losses += 1
+        self.energy_spent_total += sum(event.energy_spent for event in combat.card_events)
+        self.energy_wasted_total += sum(max(event.energy_remaining, 0.0) for event in combat.card_events)
+        self.damage_dealt_total += sum(event.damage_dealt for event in combat.card_events)
+        self.block_gained_total += sum(event.block_gained for event in combat.card_events)
+        self.status_value_total += sum(
+            sum(eff.values())
+            for event in combat.card_events
+            for eff in (event.status_effects.get("enemy", {}),)
+        )
+        history = list(self.style_history)
+        history.append(style_vector)
+        self.style_history = tuple(history[-20:])  # keep last 20 entries for smoothing
+
+    def allocate_card_identifier(self, *, prefix: str = "adaptive") -> str:
+        self.generated_cards += 1
+        suffix = f"{self.generated_cards:03d}"
+        return f"{self.mod_id}_{prefix}_{suffix}"
+
+    def record_mutation_plan(self, plan: DeckMutationPlan) -> None:
+        history = list(self.mutation_history)
+        history.append(plan.to_dict())
+        self.mutation_history = tuple(history[-50:])
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mod_id": self.mod_id,
+            "schema_version": self.schema_version,
+            "fights_recorded": self.fights_recorded,
+            "wins": self.wins,
+            "losses": self.losses,
+            "card_stats": {card_id: stats.to_dict() for card_id, stats in self.card_stats.items()},
+            "combo_stats": {key: stats.to_dict() for key, stats in self.combo_stats.items()},
+            "deck": {card_id: profile.to_dict() for card_id, profile in self.deck.items()},
+            "unlockables": {card_id: profile.to_dict() for card_id, profile in self.unlockables.items()},
+            "style_history": [vector.to_dict() for vector in self.style_history],
+            "energy_spent_total": self.energy_spent_total,
+            "energy_wasted_total": self.energy_wasted_total,
+            "damage_dealt_total": self.damage_dealt_total,
+            "block_gained_total": self.block_gained_total,
+            "status_value_total": self.status_value_total,
+            "generated_cards": self.generated_cards,
+            "mutation_history": list(self.mutation_history),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "PlayerProfile":
+        profile = cls(mod_id=str(payload.get("mod_id", "adaptive")))
+        profile.schema_version = int(payload.get("schema_version", SCHEMA_VERSION))
+        profile.fights_recorded = int(payload.get("fights_recorded", 0))
+        profile.wins = int(payload.get("wins", 0))
+        profile.losses = int(payload.get("losses", 0))
+        profile.card_stats = {
+            card_id: CardUsageStats.from_dict(data)
+            for card_id, data in (payload.get("card_stats", {}) or {}).items()
+        }
+        profile.combo_stats = {
+            key: ComboStats.from_dict(data)
+            for key, data in (payload.get("combo_stats", {}) or {}).items()
+        }
+        profile.deck = {
+            card_id: CardProfile.from_dict(data)
+            for card_id, data in (payload.get("deck", {}) or {}).items()
+        }
+        profile.unlockables = {
+            card_id: CardProfile.from_dict(data)
+            for card_id, data in (payload.get("unlockables", {}) or {}).items()
+        }
+        profile.style_history = tuple(
+            StyleVector.from_dict(entry) for entry in payload.get("style_history", [])
+        )
+        profile.energy_spent_total = float(payload.get("energy_spent_total", 0.0))
+        profile.energy_wasted_total = float(payload.get("energy_wasted_total", 0.0))
+        profile.damage_dealt_total = float(payload.get("damage_dealt_total", 0.0))
+        profile.block_gained_total = float(payload.get("block_gained_total", 0.0))
+        profile.status_value_total = float(payload.get("status_value_total", 0.0))
+        profile.generated_cards = int(payload.get("generated_cards", 0))
+        profile.mutation_history = tuple(payload.get("mutation_history", []) or [])
+        return profile
+
+
+class ProfilePersistence:
+    """Read/write helper for :class:`PlayerProfile`."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def load(self, *, mod_id: str = "adaptive") -> PlayerProfile:
+        if not self.path.exists():
+            return PlayerProfile(mod_id=mod_id)
+        payload = json.loads(self.path.read_text(encoding="utf8"))
+        profile = PlayerProfile.from_dict(payload)
+        if profile.schema_version != SCHEMA_VERSION:
+            profile.schema_version = SCHEMA_VERSION
+            self.save(profile)
+        return profile
+
+    def save(self, profile: PlayerProfile) -> None:
+        payload = profile.to_dict()
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf8")
+
+    def reset(self, *, mod_id: str = "adaptive") -> PlayerProfile:
+        profile = PlayerProfile(mod_id=mod_id)
+        self.save(profile)
+        return profile

--- a/mods/adaptive_deck_evolver/runtime.py
+++ b/mods/adaptive_deck_evolver/runtime.py
@@ -1,0 +1,360 @@
+"""Runtime integration helpers for the adaptive deck evolver."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.experimental.graalpy_rule_weaver import (
+    MechanicActivation,
+    MechanicMutation,
+)
+from modules.modbuilder import Deck
+
+from .analysis import FightingStyleHeuristic
+from .evolution import DeckEvolutionEngine
+from .models import (
+    CardProfile,
+    CombatCardEvent,
+    CombatSessionRecord,
+    DeckMutationPlan,
+    KeywordAdjustment,
+)
+from .persistence import PlayerProfile, ProfilePersistence
+
+DEFAULT_STORAGE = Path(__file__).resolve().parent / "data" / "profile.json"
+
+
+def _normalise_status_effects(
+    status_effects: Optional[Mapping[str, Mapping[str, float]]]
+) -> Mapping[str, Mapping[str, float]]:
+    if not status_effects:
+        return {}
+    normalised: Dict[str, Dict[str, float]] = {}
+    for scope, effects in status_effects.items():
+        target = scope.lower()
+        target_map: Dict[str, float] = {}
+        for name, amount in effects.items():
+            target_map[str(name).lower()] = float(amount)
+        normalised[target] = target_map
+    return normalised
+
+
+class CombatRecorder:
+    """Collects telemetry for a single combat encounter."""
+
+    def __init__(
+        self,
+        *,
+        combat_id: str,
+        enemy: str,
+        floor: int,
+        player_hp_start: float,
+        relics: Sequence[str] = (),
+        notes: Sequence[str] = (),
+    ) -> None:
+        self.combat_id = combat_id
+        self.enemy = enemy
+        self.floor = floor
+        self.player_hp_start = float(player_hp_start)
+        self._events: list[CombatCardEvent] = []
+        self.relics = tuple(str(relic) for relic in relics)
+        self.notes = [str(entry) for entry in notes]
+
+    def record_card_play(
+        self,
+        *,
+        card_id: str,
+        turn: int,
+        energy_before: float,
+        energy_spent: float,
+        energy_remaining: float,
+        damage_dealt: float = 0.0,
+        block_gained: float = 0.0,
+        player_hp_change: float = 0.0,
+        enemy_hp_change: float = 0.0,
+        status_effects: Optional[Mapping[str, Mapping[str, float]]] = None,
+        cards_drawn: int = 0,
+        cards_discarded: int = 0,
+        exhausted: bool = False,
+        retained: bool = False,
+        energy_generated: float = 0.0,
+        tags: Sequence[str] = (),
+    ) -> CombatCardEvent:
+        event = CombatCardEvent(
+            card_id=str(card_id),
+            turn=int(turn),
+            energy_before=float(energy_before),
+            energy_spent=float(energy_spent),
+            energy_remaining=float(energy_remaining),
+            damage_dealt=float(damage_dealt),
+            block_gained=float(block_gained),
+            player_hp_change=float(player_hp_change),
+            enemy_hp_change=float(enemy_hp_change),
+            status_effects=_normalise_status_effects(status_effects),
+            cards_drawn=int(cards_drawn),
+            cards_discarded=int(cards_discarded),
+            exhausted=bool(exhausted),
+            retained=bool(retained),
+            energy_generated=float(energy_generated),
+            tags=tuple(str(tag) for tag in tags),
+        )
+        self._events.append(event)
+        return event
+
+    def add_note(self, note: str) -> None:
+        self.notes.append(str(note))
+
+    def finalize(
+        self,
+        *,
+        victory: bool,
+        player_hp_end: float,
+        reward_cards: Sequence[str] = (),
+        notes: Sequence[str] = (),
+    ) -> CombatSessionRecord:
+        turn_count = max((event.turn for event in self._events), default=0)
+        combined_notes = tuple(self.notes + [str(entry) for entry in notes])
+        return CombatSessionRecord(
+            combat_id=self.combat_id,
+            enemy=self.enemy,
+            floor=self.floor,
+            victory=bool(victory),
+            turn_count=turn_count,
+            player_hp_start=self.player_hp_start,
+            player_hp_end=float(player_hp_end),
+            card_events=tuple(self._events),
+            relics=self.relics,
+            reward_cards=tuple(str(card) for card in reward_cards),
+            notes=combined_notes,
+        )
+
+
+class AdaptiveMechanicMod:
+    """High level façade that orchestrates adaptive deck evolution."""
+
+    def __init__(
+        self,
+        *,
+        mod_id: str = "adaptive_evolver",
+        storage_path: Optional[Path] = None,
+        deck: Optional[type[Deck]] = None,
+        autosave: bool = True,
+    ) -> None:
+        self.mod_id = mod_id
+        self.storage_path = storage_path or DEFAULT_STORAGE
+        self.persistence = ProfilePersistence(self.storage_path)
+        self.profile = self.persistence.load(mod_id=mod_id)
+        self.heuristic = FightingStyleHeuristic(self.profile)
+        self.engine = DeckEvolutionEngine(self.profile, self.heuristic)
+        self.deck = deck
+        self.autosave = autosave
+        self._recorders: Dict[str, CombatRecorder] = {}
+        self._base_deck_ids: set[str] = set(self.profile.deck.keys())
+        self._project = None
+        self.latest_plan: Optional[DeckMutationPlan] = None
+
+    # ------------------------------------------------------------------
+    def attach_deck(self, deck: type[Deck]) -> None:
+        self.deck = deck
+        self._base_deck_ids = set(deck.card_identifiers())
+
+    def register_base_deck(self, blueprints: Iterable[SimpleCardBlueprint]) -> None:
+        identifiers = set()
+        for blueprint in blueprints:
+            identifiers.add(blueprint.identifier)
+            if blueprint.identifier not in self.profile.deck:
+                profile = CardProfile.from_blueprint(blueprint)
+                self.profile.register_card_profile(profile)
+        if identifiers:
+            self._base_deck_ids = identifiers
+            if self.autosave:
+                self.persistence.save(self.profile)
+
+    def register_unlockables(self, blueprints: Iterable[SimpleCardBlueprint]) -> None:
+        for blueprint in blueprints:
+            profile = CardProfile.from_blueprint(blueprint)
+            self.profile.register_unlockable(profile)
+        if self.autosave:
+            self.persistence.save(self.profile)
+
+    # ------------------------------------------------------------------
+    def begin_combat(
+        self,
+        combat_id: str,
+        *,
+        enemy: str,
+        floor: int,
+        player_hp_start: float,
+        relics: Sequence[str] = (),
+        notes: Sequence[str] = (),
+    ) -> CombatRecorder:
+        recorder = CombatRecorder(
+            combat_id=str(combat_id),
+            enemy=str(enemy),
+            floor=int(floor),
+            player_hp_start=float(player_hp_start),
+            relics=relics,
+            notes=notes,
+        )
+        self._recorders[recorder.combat_id] = recorder
+        return recorder
+
+    def complete_combat(
+        self,
+        combat_id: str,
+        *,
+        victory: bool,
+        player_hp_end: float,
+        reward_cards: Sequence[str] = (),
+        notes: Sequence[str] = (),
+    ) -> DeckMutationPlan:
+        if combat_id not in self._recorders:
+            raise KeyError(f"Unknown combat identifier '{combat_id}'.")
+        recorder = self._recorders.pop(combat_id)
+        session = recorder.finalize(
+            victory=bool(victory),
+            player_hp_end=player_hp_end,
+            reward_cards=reward_cards,
+            notes=notes,
+        )
+        style_vector = self.heuristic.ingest_combat(session)
+        plan = self.engine.plan_evolution(style_vector=style_vector)
+        self.engine.apply(plan)
+        self.latest_plan = plan
+        if self.deck is not None:
+            self.apply_plan_to_deck(plan)
+        if self.autosave:
+            self.persistence.save(self.profile)
+        return plan
+
+    # ------------------------------------------------------------------
+    def apply_plan_to_deck(self, plan: DeckMutationPlan) -> None:
+        if not self.deck or plan.is_empty():
+            return
+        deck_cards = self.deck.unique_cards()
+        for mutation in plan.mutations:
+            blueprint = deck_cards.get(mutation.card_id)
+            if not blueprint:
+                continue
+            if mutation.new_value is not None:
+                object.__setattr__(blueprint, "value", int(mutation.new_value))
+            if mutation.new_upgrade_value is not None:
+                object.__setattr__(blueprint, "upgrade_value", int(mutation.new_upgrade_value))
+            if mutation.new_cost is not None:
+                object.__setattr__(blueprint, "cost", int(mutation.new_cost))
+            if mutation.new_secondary_value is not None:
+                object.__setattr__(blueprint, "secondary_value", int(mutation.new_secondary_value))
+            if mutation.new_secondary_upgrade is not None:
+                object.__setattr__(blueprint, "secondary_upgrade", int(mutation.new_secondary_upgrade))
+            self._apply_keyword_adjustments(blueprint, mutation.keyword_adjustments)
+        for card in plan.new_cards:
+            blueprint = card.to_blueprint()
+            self.deck.addCard(blueprint)
+        # Unlockables are intentionally not added directly; downstream systems can query profile.
+
+    def _apply_keyword_adjustments(
+        self,
+        blueprint: SimpleCardBlueprint,
+        adjustments: Sequence[KeywordAdjustment],
+    ) -> None:
+        if not adjustments:
+            return
+        keywords = set(blueprint.keywords)
+        values = dict(blueprint.keyword_values)
+        upgrades = dict(blueprint.keyword_upgrades)
+        for adjustment in adjustments:
+            keywords.add(adjustment.keyword)
+            if adjustment.amount is not None:
+                values[adjustment.keyword] = int(adjustment.amount)
+            if adjustment.upgrade is not None:
+                upgrades[adjustment.keyword] = int(adjustment.upgrade)
+            if adjustment.card_uses is not None:
+                object.__setattr__(blueprint, "card_uses", int(adjustment.card_uses))
+            if adjustment.card_uses_upgrade is not None:
+                object.__setattr__(blueprint, "card_uses_upgrade", int(adjustment.card_uses_upgrade))
+        object.__setattr__(blueprint, "keywords", tuple(sorted(keywords)))
+        object.__setattr__(blueprint, "keyword_values", values)
+        object.__setattr__(blueprint, "keyword_upgrades", upgrades)
+
+    # ------------------------------------------------------------------
+    def iter_dynamic_blueprints(self) -> Iterable[SimpleCardBlueprint]:
+        for identifier, profile in self.profile.deck.items():
+            if identifier not in self._base_deck_ids or profile.generated_by:
+                yield profile.to_blueprint()
+        for profile in self.profile.unlockables.values():
+            yield profile.to_blueprint()
+
+    def register_with_project(self, project: object) -> None:
+        self._project = project
+        if hasattr(project, "register_mechanic_blueprint_provider"):
+            project.register_mechanic_blueprint_provider(self.iter_dynamic_blueprints)
+        mutation = self._build_runtime_mutation()
+        if hasattr(project, "register_mechanic_mutation"):
+            project.register_mechanic_mutation(mutation, activate=False)
+
+    # ------------------------------------------------------------------
+    def _build_runtime_mutation(self) -> MechanicMutation:
+        identifier = f"{self.mod_id}:adaptive-sync"
+
+        def apply(context) -> MechanicActivation:
+            reverts = []
+            for profile in self.profile.deck.values():
+                reverts.append(
+                    context.adjust_card_values(
+                        profile.identifier,
+                        value=profile.value,
+                        upgrade_value=profile.upgrade_value,
+                        cost=profile.cost,
+                        secondary_value=profile.secondary_value,
+                        secondary_upgrade=profile.secondary_upgrade,
+                    )
+                )
+                if profile.description or profile.upgrade_description:
+                    reverts.append(
+                        context.set_card_description(
+                            profile.identifier,
+                            description=profile.description,
+                            upgrade_description=profile.upgrade_description,
+                        )
+                    )
+                for keyword in profile.keywords:
+                    reverts.append(
+                        context.add_keyword_to_card(
+                            profile.identifier,
+                            keyword,
+                            amount=profile.keyword_values.get(keyword),
+                            upgrade=profile.keyword_upgrades.get(keyword),
+                            card_uses=profile.card_uses if keyword == "exhaustive" else None,
+                            card_uses_upgrade=profile.card_uses_upgrade if keyword == "exhaustive" else None,
+                        )
+                    )
+            metadata = {
+                "deck_cards": len(self.profile.deck),
+                "unlockables": len(self.profile.unlockables),
+            }
+            return MechanicActivation(
+                identifier=identifier,
+                revert_callbacks=tuple(reverts),
+                metadata=metadata,
+            )
+
+        return MechanicMutation(
+            identifier=identifier,
+            description="Synchronise adaptive deck state with persistent profile.",
+            apply=apply,
+            priority=50,
+            tags=("adaptive", "evolution", self.mod_id),
+            metadata={"mod_id": self.mod_id},
+        )
+
+    # ------------------------------------------------------------------
+    def save(self) -> None:
+        self.persistence.save(self.profile)
+
+    def reset_profile(self) -> PlayerProfile:
+        self.profile = self.persistence.reset(mod_id=self.mod_id)
+        self.heuristic = FightingStyleHeuristic(self.profile)
+        self.engine = DeckEvolutionEngine(self.profile, self.heuristic)
+        self._base_deck_ids = set()
+        return self.profile

--- a/tests/test_adaptive_deck_evolver.py
+++ b/tests/test_adaptive_deck_evolver.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mods.adaptive_deck_evolver import AdaptiveMechanicMod, DeckMutationPlan
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.modbuilder import Deck
+
+
+class _TestDeck(Deck):
+    pass
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_adaptive_mechanic_mod_generates_evolution_plan(
+    tmp_path: Path, use_real_dependencies: bool
+) -> None:
+    storage_path = tmp_path / "profile.json"
+    _TestDeck.clear()
+    strike = SimpleCardBlueprint(
+        identifier="strike_buddy",
+        title="Buddy Strike",
+        description="Deal 6 damage.",
+        cost=1,
+        card_type="ATTACK",
+        target="ENEMY",
+        rarity="COMMON",
+        value=6,
+        upgrade_value=3,
+    )
+    guard = SimpleCardBlueprint(
+        identifier="guard_pal",
+        title="Buddy Guard",
+        description="Gain 5 Block.",
+        cost=1,
+        card_type="SKILL",
+        target="SELF",
+        rarity="COMMON",
+        value=5,
+        upgrade_value=3,
+        effect="block",
+    )
+    _TestDeck.addCard(strike)
+    _TestDeck.addCard(guard)
+
+    mod = AdaptiveMechanicMod(
+        mod_id="buddy_mod",
+        storage_path=storage_path,
+        deck=_TestDeck,
+        autosave=True,
+    )
+    mod.register_base_deck(_TestDeck.cards())
+    if use_real_dependencies:
+        mod.save()
+        assert storage_path.exists()
+
+    recorder = mod.begin_combat(
+        "combat-1",
+        enemy="Lagavulin",
+        floor=1,
+        player_hp_start=70,
+        relics=("Lantern",),
+    )
+
+    for turn in range(1, 4):
+        recorder.record_card_play(
+            card_id="strike_buddy",
+            turn=turn,
+            energy_before=3,
+            energy_spent=1,
+            energy_remaining=2,
+            damage_dealt=12,
+            enemy_hp_change=-12,
+            status_effects={"enemy": {"vulnerable": 2}},
+            cards_drawn=1,
+            exhausted=False,
+            retained=False,
+        )
+        recorder.record_card_play(
+            card_id="guard_pal",
+            turn=turn,
+            energy_before=2,
+            energy_spent=1,
+            energy_remaining=1,
+            block_gained=2,
+            player_hp_change=-3,
+            status_effects={"enemy": {"weak": 1}},
+            cards_drawn=0,
+            exhausted=False,
+            retained=True,
+        )
+
+    recorder.record_card_play(
+        card_id="guard_pal",
+        turn=4,
+        energy_before=3,
+        energy_spent=2,
+        energy_remaining=1,
+        block_gained=1,
+        player_hp_change=-6,
+        status_effects={"player": {"frail": 1}},
+        cards_drawn=0,
+        exhausted=True,
+        retained=False,
+    )
+
+    plan = mod.complete_combat(
+        "combat-1",
+        victory=True,
+        player_hp_end=62,
+        reward_cards=("flex-option",),
+    )
+
+    assert isinstance(plan, DeckMutationPlan)
+    assert not plan.is_empty()
+    assert plan.style_vector is not None
+    assert plan is mod.latest_plan
+    assert storage_path.exists()
+
+    payload = json.loads(storage_path.read_text(encoding="utf8"))
+    assert payload["fights_recorded"] >= 1
+    assert payload["wins"] == 1
+
+    if plan.mutations:
+        mutated_ids = {mutation.card_id for mutation in plan.mutations}
+        assert "guard_pal" in mutated_ids
+    if plan.new_cards:
+        assert any(card.generated_by for card in plan.new_cards)
+
+    deck_cards = _TestDeck.unique_cards()
+    guard_blueprint = deck_cards.get("guard_pal")
+    if guard_blueprint is not None:
+        assert guard_blueprint.value >= 5 or guard_blueprint.cost <= 1
+
+    dynamic_ids = {bp.identifier for bp in mod.iter_dynamic_blueprints()}
+    for card in plan.new_cards:
+        assert card.identifier in dynamic_ids


### PR DESCRIPTION
## Summary
- add a mechanics-only adaptive deck evolver package with persistence, analytics and runtime integration hooks
- expose heuristic, evolution and runtime helpers through the mods namespace and plugin manager
- cover the new workflow with dedicated tests and extend the futures roadmap with a tuning console task

## Testing
- pytest tests/test_adaptive_deck_evolver.py

------
https://chatgpt.com/codex/tasks/task_e_68dccc05b62c83278dc699d1f2c7e5b9