### PR TITLE
Add relic framework and telemetry core relic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ directly to Python developers.
   single `.pystsmod` archive plus a ModTheSpire loader jar for memory-only
   deployment workflows.
 - Runtime bootstrap helpers (`modules.modbuilder.runtime_env`) that describe bundled Python packages and generate platform-specific activation commands.
+- Auto-registering `Relic` base class with a global registry so adaptive mods can expose gameplay artefacts without manual BaseMod wiring.
 - Forward-looking roadmap documented in `futures.md`.
 - Built-in deck analytics helper that converts validation snapshots into tables and JSON artefacts for dashboards and plugins.
 - Mechanics-only mod support that activates the `experimental.graalpy_rule_weaver`

--- a/futures.md
+++ b/futures.md
@@ -223,3 +223,8 @@
   script paths/resources, validates JSON/YAML structure ahead of bundling, and
   publishes a manifest to `PLUGIN_MANAGER` so CI pipelines can diff mechanic
   packs for unexpected mutations.
+- [todo] **Adaptive telemetry core visual pass** – Produce production-quality relic art
+  and outline textures for the new Adaptive Telemetry Core relic. Usage: create
+  high contrast PNGs under `assets/adaptive_evolver/images/relics/` and update
+  the relic documentation with sizing guidelines so bundling workflows include
+  finalised art instead of placeholders.

--- a/mods/__init__.py
+++ b/mods/__init__.py
@@ -14,13 +14,15 @@ from __future__ import annotations
 
 from plugins import PLUGIN_MANAGER
 
+from .adaptive_deck_evolver import AdaptiveTelemetryCore
 from .adaptive_deck_evolver.runtime import AdaptiveMechanicMod
 
-__all__ = ["AdaptiveMechanicMod"]
+__all__ = ["AdaptiveMechanicMod", "AdaptiveTelemetryCore"]
 
 # Provide friendly aliases for plugin consumers while keeping the automatic
 # lazy exposure active.  The plugin manager already exports every repository
 # module lazily, however exposing the high level factory under a predictable key
 # makes extension authoring substantially easier.
 PLUGIN_MANAGER.expose("adaptive_mechanic_mod_factory", AdaptiveMechanicMod)
+PLUGIN_MANAGER.expose("adaptive_telemetry_core_relic", AdaptiveTelemetryCore)
 PLUGIN_MANAGER.expose_module("mods.adaptive_deck_evolver", alias="adaptive_deck_evolver")

--- a/mods/adaptive_deck_evolver/__init__.py
+++ b/mods/adaptive_deck_evolver/__init__.py
@@ -37,6 +37,7 @@ from .models import (
     StyleVector,
 )
 from .persistence import PlayerProfile, ProfilePersistence
+from .relics import AdaptiveTelemetryCore
 from .runtime import AdaptiveMechanicMod, CombatRecorder
 
 __all__ = [
@@ -50,6 +51,7 @@ __all__ = [
     "DeckEvolutionEngine",
     "DeckMutation",
     "DeckMutationPlan",
+    "AdaptiveTelemetryCore",
     "FightingStyleHeuristic",
     "PlayerProfile",
     "ProfilePersistence",

--- a/mods/adaptive_deck_evolver/relics.py
+++ b/mods/adaptive_deck_evolver/relics.py
@@ -1,0 +1,63 @@
+"""Adaptive deck evolver relic implementations."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from modules.basemod_wrapper.relics import Relic
+
+
+class AdaptiveTelemetryCore(Relic):
+    """Relic that amplifies adaptive deck evolution feedback."""
+
+    mod_id = "adaptive_evolver"
+    identifier = "adaptive_evolver:telemetry_core"
+    display_name = "Adaptive Telemetry Core"
+    description_text = (
+        "Records combat telemetry at an enhanced resolution. After each victory the evolution "
+        "plan receives synergy-focused notes and metadata boosts."
+    )
+    flavor_text = "\"Every strike is a datapoint, every defence a hypothesis.\""
+    tier = "RARE"
+    landing_sound = "MAGICAL"
+    relic_pool = "SHARED"
+    image = "adaptive_evolver/images/relics/telemetry_core.png"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.counter = 0
+
+    def on_combat_begin(self, mod: object, recorder: object) -> None:
+        self.counter += 1
+        if hasattr(recorder, "add_note"):
+            recorder.add_note("Adaptive Telemetry Core calibrates to the encounter.")
+
+    def on_plan_finalised(self, mod: object, plan: object) -> None:
+        notes: Iterable[str] = getattr(plan, "notes", ()) or ()
+        enhanced_notes = list(dict.fromkeys(tuple(notes) + ("Telemetry Core prioritised synergy lines",)))
+        try:
+            plan.notes = tuple(enhanced_notes)
+        except Exception:
+            pass
+        mutations = getattr(plan, "mutations", ()) or ()
+        for mutation in mutations:
+            try:
+                mutation_notes = list(dict.fromkeys(tuple(getattr(mutation, "notes", ())) + ("Telemetry Core reinforcement",)))
+                mutation.notes = tuple(mutation_notes)
+            except Exception:
+                pass
+            metadata = dict(getattr(mutation, "metadata", {}) or {})
+            metadata.setdefault("telemetry_core_boost", True)
+            mutation.metadata = metadata
+        style_vector = getattr(plan, "style_vector", None)
+        if style_vector is not None:
+            if hasattr(style_vector, "combo"):
+                style_vector.combo += 0.35
+            summary = getattr(style_vector, "summary", "") or ""
+            if "Telemetry Core" not in summary:
+                new_summary = f"{summary} | Telemetry Core boost" if summary else "Telemetry Core boost"
+                try:
+                    style_vector.summary = new_summary
+                except Exception:
+                    pass
+        if getattr(plan, "source_combat", None) is None:
+            plan.source_combat = f"telemetry_core:{self.counter}"

--- a/modules/basemod_wrapper/README.md
+++ b/modules/basemod_wrapper/README.md
@@ -38,6 +38,8 @@ are also published to the global plugin manager (`plugins.PLUGIN_MANAGER`):
   distribution.
 - `SimpleCardBlueprint` and `register_simple_card`: declarative helpers for
   building everyday cards without hand-written subclasses.
+- `Relic` and `RELIC_REGISTRY`: declarative relic base class with automatic
+  registration and plugin-friendly discovery.
 - `BaseModEnvironment`: access to the resolved dependency jars and default
   classpath should you need to integrate with custom tooling.
 
@@ -362,6 +364,39 @@ runs reuse cached builds and only reprocess when the source PNG changes.
 If you want to bypass `ModProject` entirely you can call
 `register_simple_card(project, blueprint)` directly. This is primarily useful
 inside custom tooling or plugin workflows.
+
+## Relic authoring
+
+Subclass :class:`modules.basemod_wrapper.relics.Relic` to register relics
+without manual plumbing. The metaclass instantiates a prototype as soon as the
+class is defined, stores it inside :data:`modules.basemod_wrapper.relics.RELIC_REGISTRY`
+and wires the prototype into `ModProject` when
+:meth:`modules.basemod_wrapper.project.ModProject.enable_runtime` runs.
+
+```python
+from modules.basemod_wrapper.relics import Relic
+
+
+class AdaptiveTelemetryCore(Relic):
+    mod_id = "adaptive_evolver"
+    identifier = "adaptive_evolver:telemetry_core"
+    display_name = "Adaptive Telemetry Core"
+    description_text = "Records combat telemetry and boosts evolution planning."
+    tier = "RARE"
+    landing_sound = "MAGICAL"
+    relic_pool = "SHARED"
+    image = "adaptive_evolver/images/relics/telemetry_core.png"
+
+    def on_combat_begin(self, mod, recorder):
+        recorder.add_note("Telemetry Core calibrates to the encounter.")
+
+    def on_plan_finalised(self, mod, plan):
+        plan.notes = tuple(sorted(set(plan.notes + ("Telemetry Core boost",))))
+```
+
+Projects can also opt-in manually via
+``modules.basemod_wrapper.relics.RELIC_REGISTRY.install_on_project(project)``
+when wiring mechanics-only experiences.
 
 ## Runtime iteration
 

--- a/modules/basemod_wrapper/__init__.py
+++ b/modules/basemod_wrapper/__init__.py
@@ -33,6 +33,7 @@ from .keywords import (
     apply_persistent_card_changes,
     keyword_scheduler,
 )
+from .relics import Relic, RELIC_REGISTRY
 from . import experimental
 
 ensure_jpype()
@@ -428,6 +429,8 @@ PLUGIN_MANAGER.expose("create_project", create_project)
 PLUGIN_MANAGER.expose("compileandbundle", compileandbundle)
 PLUGIN_MANAGER.expose("SimpleCardBlueprint", SimpleCardBlueprint)
 PLUGIN_MANAGER.expose("register_simple_card", register_simple_card)
+PLUGIN_MANAGER.expose("Relic", Relic)
+PLUGIN_MANAGER.expose("RelicRegistry", RELIC_REGISTRY)
 PLUGIN_MANAGER.expose("ModProject", ModProject)
 PLUGIN_MANAGER.expose("ProjectLayout", ProjectLayout)
 PLUGIN_MANAGER.expose("BundleOptions", BundleOptions)

--- a/modules/basemod_wrapper/relics.py
+++ b/modules/basemod_wrapper/relics.py
@@ -1,0 +1,218 @@
+"""Relic base classes and registration helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import import_module
+from typing import Callable, Dict, Iterable, Iterator, Mapping, Optional, Tuple, Type
+
+from .loader import BaseModBootstrapError
+from plugins import PLUGIN_MANAGER
+
+
+def _wrapper_module():
+    return import_module("modules.basemod_wrapper")
+
+
+def _cardcrawl():
+    try:
+        return getattr(_wrapper_module(), "cardcrawl")
+    except Exception:
+        return None
+
+
+def _basemod():
+    try:
+        return getattr(_wrapper_module(), "basemod")
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=1)
+def _custom_relic_base():
+    basemod = _basemod()
+    if basemod is not None:
+        try:
+            return basemod.abstracts.CustomRelic
+        except Exception:
+            pass
+
+    class _FallbackCustomRelic:
+        def __init__(self, relic_id: str, image_path: str, tier: object, landing_sound: object) -> None:
+            self.relicId = relic_id
+            self.imgUrl = image_path
+            self.tier = tier
+            self.landing_sound = landing_sound
+            self.counter = 0
+            self.grayscale = False
+            self.name = relic_id
+            self.description = ""
+            self.flavorText = ""
+
+        def makeCopy(self):  # pragma: no cover - trivial fallback behaviour
+            return self.__class__()
+
+    return _FallbackCustomRelic
+
+
+@dataclass(frozen=True)
+class RelicRecord:
+    identifier: str
+    mod_id: str
+    cls: Type["Relic"]
+    instance: "Relic"
+    pool: str
+    color_id: Optional[str]
+    image: str
+
+    def spawn_instance(self) -> "Relic":
+        relic = self.cls.__new__(self.cls)
+        self.cls.__init__(relic)
+        return relic
+
+
+class RelicRegistry:
+    """Registry tracking relic subclasses and their prototypes."""
+
+    def __init__(self) -> None:
+        self._records: Dict[str, RelicRecord] = {}
+        self._by_mod: Dict[str, Dict[str, RelicRecord]] = {}
+
+    def register(self, cls: Type["Relic"], instance: "Relic") -> RelicRecord:
+        identifier = instance.identifier
+        if identifier in self._records:
+            existing = self._records[identifier]
+            raise BaseModBootstrapError(
+                f"Relic '{identifier}' already registered by {existing.cls.__module__}.{existing.cls.__name__}."
+            )
+        record = RelicRecord(
+            identifier=identifier,
+            mod_id=instance.mod_id,
+            cls=cls,
+            instance=instance,
+            pool=cls.relic_pool,
+            color_id=cls.color_id,
+            image=instance.image_path,
+        )
+        self._records[identifier] = record
+        self._by_mod.setdefault(instance.mod_id, {})[identifier] = record
+        return record
+
+    def unregister(self, identifier: str) -> None:
+        record = self._records.pop(identifier, None)
+        if record is None:
+            return
+        mod_records = self._by_mod.get(record.mod_id)
+        if mod_records and identifier in mod_records:
+            del mod_records[identifier]
+            if not mod_records:
+                self._by_mod.pop(record.mod_id, None)
+
+    def record(self, identifier: str) -> Optional[RelicRecord]:
+        return self._records.get(identifier)
+
+    def for_mod(self, mod_id: str) -> Tuple[RelicRecord, ...]:
+        records = self._by_mod.get(mod_id, {})
+        return tuple(records.values())
+
+    def install_on_project(self, project: object) -> None:
+        mod_id = getattr(project, "mod_id", None)
+        if not mod_id:
+            return
+        for record in self.for_mod(str(mod_id)):
+            if hasattr(project, "register_relic_record"):
+                project.register_relic_record(record)
+
+    def items(self) -> Iterable[Tuple[str, RelicRecord]]:  # pragma: no cover - trivial helper
+        return self._records.items()
+
+
+RELIC_REGISTRY = RelicRegistry()
+
+
+def _resolve_enum(container: object, name: str, label: str) -> object:
+    if container is None:
+        return name
+    if hasattr(container, "valueOf"):
+        try:
+            return container.valueOf(name)
+        except Exception as exc:
+            raise BaseModBootstrapError(f"Unknown {label} '{name}'.") from exc
+    try:
+        return getattr(container, name)
+    except AttributeError as exc:
+        raise BaseModBootstrapError(f"Unknown {label} '{name}'.") from exc
+
+
+class RelicMeta(type):
+    def __new__(mcls, name: str, bases: Tuple[type, ...], namespace: Mapping[str, object]):
+        cls = super().__new__(mcls, name, bases, dict(namespace))
+        if getattr(cls, "_abstract", False):
+            return cls
+        if not getattr(cls, "identifier", None):
+            raise BaseModBootstrapError(f"Relic subclass '{cls.__name__}' must define an identifier.")
+        if not getattr(cls, "mod_id", None):
+            raise BaseModBootstrapError(f"Relic subclass '{cls.__name__}' must define mod_id.")
+        instance = cls()
+        RELIC_REGISTRY.register(cls, instance)
+        return cls
+
+
+class Relic(_custom_relic_base(), metaclass=RelicMeta):  # type: ignore[misc]
+    _abstract = True
+    mod_id: str = ""
+    identifier: str = ""
+    relic_pool: str = "SHARED"
+    color_id: Optional[str] = None
+    tier: str = "COMMON"
+    landing_sound: str = "FLAT"
+    display_name: Optional[str] = None
+    description_text: str = ""
+    flavor_text: str = ""
+    image: Optional[str] = None
+
+    def __init__(self) -> None:
+        if type(self) is Relic:
+            return
+        if not self.identifier:
+            raise BaseModBootstrapError("Relic subclasses must define an identifier.")
+        tier_enum = _resolve_enum(
+            getattr(getattr(getattr(_cardcrawl(), "relics", None), "AbstractRelic", None), "RelicTier", None),
+            self.tier,
+            "relic tier",
+        )
+        landing_enum = _resolve_enum(
+            getattr(getattr(getattr(_cardcrawl(), "relics", None), "AbstractRelic", None), "LandingSound", None),
+            self.landing_sound,
+            "relic landing sound",
+        )
+        image_path = self.image or self.default_image_path()
+        super().__init__(self.identifier, image_path, tier_enum, landing_enum)
+        self.mod_id = self.mod_id
+        self.image_path = image_path
+        if self.display_name:
+            self.name = self.display_name
+        if self.description_text:
+            self.description = self.description_text
+        if self.flavor_text:
+            self.flavorText = self.flavor_text
+
+    def default_image_path(self) -> str:
+        local_id = self.identifier.split(":")[-1]
+        return f"{self.mod_id}/images/relics/{local_id}.png"
+
+    def spawn_copy(self) -> "Relic":
+        return type(self)()
+
+    def on_combat_begin(self, mod: object, recorder: object) -> None:
+        return None
+
+    def on_plan_finalised(self, mod: object, plan: object) -> None:
+        return None
+
+
+Relic._abstract = False  # type: ignore[attr-defined]
+
+PLUGIN_MANAGER.expose("Relic", Relic)
+PLUGIN_MANAGER.expose("RelicRegistry", RELIC_REGISTRY)
+PLUGIN_MANAGER.expose_module("modules.basemod_wrapper.relics", alias="basemod_relics")

--- a/research/basemod_CustomRelic.java
+++ b/research/basemod_CustomRelic.java
@@ -1,0 +1,59 @@
+package basemod.abstracts;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+
+public abstract class CustomRelic extends AbstractRelic
+{
+	public CustomRelic(String id, Texture texture, RelicTier tier, LandingSound sfx)
+	{
+		super(id, "", tier, sfx);
+		texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+		setTexture(texture);
+	}
+
+	public CustomRelic(String id, Texture texture, Texture outline, RelicTier tier, LandingSound sfx)
+	{
+		super(id, "", tier, sfx);
+		texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+		outline.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+		setTextureOutline(texture, outline);
+	}
+
+	public CustomRelic(String id, String imgName, RelicTier tier, LandingSound sfx)
+	{
+		super(id, imgName, tier, sfx);
+	}
+
+	public void setTexture(Texture t)
+	{
+		img = t;
+		outlineImg = t;
+	}
+
+	public void setTextureOutline(Texture t, Texture o)
+	{
+		img = t;
+		outlineImg = o;
+	}
+
+	@Override
+	public void loadLargeImg() {
+		if (this.largeImg == null) {
+			String path = "images/largeRelics/" + this.imgUrl;
+			if (Gdx.files.internal(path).exists())
+				this.largeImg = ImageMaster.loadImage(path);
+		}
+	}
+
+	@Override
+	public AbstractRelic makeCopy() {
+		try{
+			return this.getClass().newInstance();
+		}catch(InstantiationException | IllegalAccessException e) {
+			throw new RuntimeException("BaseMod failed to auto-generate makeCopy for relic: " + relicId);
+		}
+	}
+}

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -114,6 +114,58 @@ class StubCustomCard:
         self.magicNumber = self.baseMagicNumber
 
 
+class StubRelicTier:
+    COMMON = "COMMON"
+    UNCOMMON = "UNCOMMON"
+    RARE = "RARE"
+    BOSS = "BOSS"
+    SHOP = "SHOP"
+
+    @staticmethod
+    def valueOf(name: str):
+        return getattr(StubRelicTier, name)
+
+
+class StubLandingSound:
+    FLAT = "FLAT"
+    SOLID = "SOLID"
+    CLINK = "CLINK"
+    MAGICAL = "MAGICAL"
+
+    @staticmethod
+    def valueOf(name: str):
+        return getattr(StubLandingSound, name)
+
+
+class StubRelicType:
+    SHARED = "SHARED"
+    RED = "RED"
+    GREEN = "GREEN"
+    BLUE = "BLUE"
+    PURPLE = "PURPLE"
+    CUSTOM = "CUSTOM"
+
+    @staticmethod
+    def valueOf(name: str):
+        return getattr(StubRelicType, name)
+
+
+class StubCustomRelic:
+    def __init__(self, relic_id: str, image: str, tier: object, sound: object) -> None:
+        self.relicId = relic_id
+        self.imgUrl = image
+        self.tier = tier
+        self.landing_sound = sound
+        self.counter = 0
+        self.grayscale = False
+        self.name = relic_id
+        self.description = ""
+        self.flavorText = ""
+
+    def makeCopy(self):
+        return type(self)(self.relicId, self.imgUrl, self.tier, self.landing_sound)
+
+
 class StubStrengthPower:
     def __init__(self, owner, amount) -> None:
         self.owner = owner

--- a/tests/test_relics.py
+++ b/tests/test_relics.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import pytest
+
+from modules.basemod_wrapper import create_project
+from modules.basemod_wrapper.cards import SimpleCardBlueprint
+from modules.basemod_wrapper.relics import RELIC_REGISTRY, Relic
+from modules.basemod_wrapper import relics as relics_module
+from mods.adaptive_deck_evolver import AdaptiveMechanicMod, AdaptiveTelemetryCore
+from modules.modbuilder import Deck
+
+
+class _RelicTestDeck(Deck):
+    pass
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_relic_subclass_registration_and_project_integration(
+    use_real_dependencies: bool, stubbed_runtime
+) -> None:
+    class BuddyDataCore(Relic):
+        mod_id = "unit_test_mod"
+        identifier = "unit_test_mod:buddy_core"
+        display_name = "Buddy Core"
+        description_text = "Test relic wiring."
+        tier = "COMMON"
+        landing_sound = "CLINK"
+        relic_pool = "SHARED"
+        image = "unit_test_mod/images/relics/buddy_core.png"
+
+        def on_plan_finalised(self, mod: object, plan: object) -> None:
+            notes = list(getattr(plan, "notes", ()))
+            notes.append("buddy-core-note")
+            plan.notes = tuple(dict.fromkeys(notes))
+
+    try:
+        record = RELIC_REGISTRY.record("unit_test_mod:buddy_core")
+        assert record is not None
+        plan = SimpleNamespace(notes=tuple(), mutations=tuple(), style_vector=None, source_combat=None)
+        relic_instance = record.spawn_instance()
+        relic_instance.on_plan_finalised(SimpleNamespace(), plan)
+        assert "buddy-core-note" in plan.notes
+
+        project = create_project("unit_test_mod", "Unit Test", "Buddy", "Relic test")
+        project.register_relic_record(record)
+        assert "unit_test_mod:buddy_core" in project._relic_records
+
+        if not use_real_dependencies:
+            basemod_stub = relics_module._basemod()
+            basemod_stub.BaseMod.relics_registered.clear()
+            project._register_relics()
+            assert any(
+                entry[0].relicId == record.identifier for entry in basemod_stub.BaseMod.relics_registered
+            )
+        else:
+            clone = record.spawn_instance()
+            assert clone.relicId == record.identifier
+    finally:
+        RELIC_REGISTRY.unregister("unit_test_mod:buddy_core")
+
+
+@pytest.mark.parametrize("use_real_dependencies", [False, True])
+def test_adaptive_mod_telemetry_core_effect(use_real_dependencies: bool, tmp_path) -> None:
+    _RelicTestDeck.clear()
+    strike = SimpleCardBlueprint(
+        identifier="telemetry_strike",
+        title="Telemetry Strike",
+        description="Deal 6 damage.",
+        cost=1,
+        card_type="ATTACK",
+        target="ENEMY",
+        rarity="COMMON",
+        value=6,
+        upgrade_value=3,
+    )
+    block = SimpleCardBlueprint(
+        identifier="telemetry_guard",
+        title="Telemetry Guard",
+        description="Gain 5 Block.",
+        cost=1,
+        card_type="SKILL",
+        target="SELF",
+        rarity="COMMON",
+        value=5,
+        upgrade_value=3,
+        effect="block",
+    )
+    _RelicTestDeck.addCard(strike)
+    _RelicTestDeck.addCard(block)
+
+    mod = AdaptiveMechanicMod(
+        mod_id="adaptive_evolver",
+        storage_path=tmp_path / "profile.json",
+        deck=_RelicTestDeck,
+        autosave=False,
+    )
+    mod.register_base_deck(_RelicTestDeck.cards())
+
+    recorder = mod.begin_combat(
+        "telemetry-combat",
+        enemy="Lagavulin",
+        floor=2,
+        player_hp_start=70,
+        relics=(AdaptiveTelemetryCore.identifier,),
+    )
+    assert any("Telemetry Core" in note for note in recorder.notes)
+
+    for turn in range(1, 4):
+        recorder.record_card_play(
+            card_id="telemetry_strike",
+            turn=turn,
+            energy_before=3,
+            energy_spent=1,
+            energy_remaining=2,
+            damage_dealt=9,
+            enemy_hp_change=-9,
+            status_effects={"enemy": {"vulnerable": 1}},
+            cards_drawn=1,
+        )
+        recorder.record_card_play(
+            card_id="telemetry_guard",
+            turn=turn,
+            energy_before=2,
+            energy_spent=1,
+            energy_remaining=1,
+            block_gained=4,
+            player_hp_change=-2,
+            status_effects={"enemy": {"weak": 1}},
+        )
+
+    plan = mod.complete_combat(
+        "telemetry-combat",
+        victory=True,
+        player_hp_end=64,
+        reward_cards=("adaptive-option",),
+    )
+
+    assert "Telemetry Core" in " ".join(plan.notes)
+    if plan.mutations:
+        for mutation in plan.mutations:
+            assert mutation.metadata.get("telemetry_core_boost") is True
+            assert any("Telemetry Core" in note for note in mutation.notes)
+    if plan.style_vector is not None:
+        assert "Telemetry Core" in plan.style_vector.summary
+        assert plan.style_vector.combo >= 0
+    assert plan.source_combat is not None and plan.source_combat.startswith("telemetry_core")


### PR DESCRIPTION
## Summary
- add a BaseMod-compatible `Relic` base class with registry helpers and project integration
- implement the Adaptive Telemetry Core relic and wire it into the adaptive deck evolver runtime and plugin exports
- extend documentation, research notes, and automated tests to cover relic authoring and behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcf87cbe408327aea66835dd677e87