### PR TITLE
Plan DigitalesMonster mod groundwork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Repository authoring guidelines
-
 - Always favour the highest-level helpers exposed by the project when extending gameplay guides or code samples.
-- In particular, use `modules.modbuilder.Deck`, `modules.modbuilder.Character`, and `modules.basemod_wrapper.keywords.Keyword` (plus their documented helpers) instead of low-level BaseMod plumbing whenever possible.
-- Documentation in this repository should explicitly demonstrate the Deck/Character/Keyword workflow so that future contributors reach for those abstractions first.
+- In particular, use `modules.modbuilder.Deck`, `modules.modbuilder.Character`, and `modules.basemod_wrapper.keywords.Keyword` (
+plus their documented helpers) instead of low-level BaseMod plumbing whenever possible.
+- Documentation in this repository should explicitly demonstrate the Deck/Character/Keyword workflow so that future contributors
+ reach for those abstractions first.
 - When adding new teaching material remember to point readers back to the ready-made bundling helpers such as `Character.createMod` and `Deck.statistics()` so tutorials stay aligned with the automation surface.
+- Binary assets must never be committed. When image placeholders are required, encode them as base64 strings inside text files and document their purpose.

--- a/digimonmoddevelopmentplan.md
+++ b/digimonmoddevelopmentplan.md
@@ -1,0 +1,35 @@
+# Entwicklungsplan "DigitalesMonster"-Mod
+
+Die folgenden Schritte sind als eigenständige, klar umrissene Aufgaben konzipiert. Jede Aufgabe ist mit `[todo]` markiert und baut auf den vorangehenden auf. Nach der Umsetzung aller Aufgaben ist der Mod gemäß der Spezifikation funktionsvollständig.
+
+1. [todo] Projektgrundlage vorbereiten: Neues Mod-Paket unter Nutzung von `modules.modbuilder` anlegen, bestehenden Plugin-Manager einbinden und GraalPy-Experiment über `experimental.graalpy_runtime` aktivieren.
+2. [todo] Forschungsbasis erweitern: Für jede Form der Agumon-Evolutionslinien (Adventure, Tamers, Savers inkl. Armor- und Burst-Varianten) deutsche Attackennamen und relevante Seriendetails über DigiPedia sammeln und im `research/`-Verzeichnis dokumentieren.
+3. [todo] Persistente Datenfelder prüfen und erweitern: Bestehende Persistenz-Utilities (z. B. StSLib PersistFields) evaluieren und ein Speicherschema für Level-Stabilitätswerte (Start, Max, Aktuell pro Level) definieren.
+4. [todo] Stance-Basisklasse prüfen: Vorhandene `Stance`-Implementierungen analysieren und ein erweiterbares Digimon-Stance-Framework entwerfen, das Plug-ins Zugriff auf alle relevanten Hooks erhält.
+5. [todo] Rookie-Stance „Natürliches Rookie-Level" implementieren: HP-Werte, Grundwerte und Start-Buffs definieren, Stabilitätslogik einbinden und Charakterstart auf dieses Level festlegen.
+6. [todo] Champion-Stance mit Digivice-Voraussetzungen implementieren: Stance-Werte, Stabilitätsverwaltung und Rückfallmechanik inklusive Trigger bei Stabilität ≤ 0 fertigstellen.
+7. [todo] Ultra-Stance (inkl. SkullGreymon-Abzweig) implementieren: Zusätzliche Modifikatoren, Rückfallpfad und spezielle Debuffs für instabile Digitation ausarbeiten.
+8. [todo] Mega- und Burst-Formen (inkl. Warp-Digitation) als Stances umsetzen: Werte, dauerhafte Buffs und Sonderlogiken (z. B. Burst Mode HP-Modifikatoren) hinterlegen.
+9. [todo] Armor-Stance erstellen: Interaktion mit Digi-Eiern abbilden, alternative Level-Pipeline und Stabilitätsverhalten implementieren.
+10. [todo] Jogress-/Fusion-Stance(s) (Omnimon etc.) implementieren: Zufalls- oder triggerbasierte Aktivierung und Rückkehrbedingungen definieren.
+11. [todo] Level-Übergangsmanager programmieren: Karten-, Relikt- und Kampf-Trigger auswerten, Stabilitätsanpassungen ausführen und Stance-Wechsel koordinieren.
+12. [todo] Stabilitäts-Persistenz verdrahten: Startwert-/Maxwert-Anpassungen bei Sieg/Niederlage erfassen und zwischen Runs speichern.
+13. [todo] Gemeinsamen Kartenpool (levelunabhängige Angriffe/Blocks/Skills/Power) mit vollständigen deutschen Texten und Upgrades anlegen, einschließlich `inner_card_image`-Referenzen.
+14. [todo] Level-spezifische Attack-Karten implementieren: Für jede Digimon-Form passende kanonische Attackennamen und Effekte codieren, Level-Beschränkungen und Upgrades hinzufügen.
+15. [todo] Level-spezifische Skill- und Power-Karten umsetzen: Mechaniken auf Stance-Fähigkeiten abstimmen, Stabilitäts-Interaktion berücksichtigen und Upgrades anbieten.
+16. [todo] DigiSoul-Buff als neues Keyword/Power implementieren: Aufladung über Angriffe, Interaktion mit Digivice-Relikten und Karten „DigiSoul aufladen!“ und „Digitieren“ sicherstellen.
+17. [todo] Digimodify-System abbilden: Karten „Digimodify“ und individuelle Digimodify-Karten (z. B. „Highspeed Plugin A/B“, „Weiße Flügel“) erstellen, Triggerlogik für D-Power/D-Arc prüfen.
+18. [todo] Schwarze-Digitation-Karten (Uncommon & Rare) programmieren: Zufällige Levelwechsel, HP/Stärke-Nachwirkungen und Todes-Trigger exakt implementieren.
+19. [todo] Reliktfamilien erstellen: Digivices, Wappen, Armor-Eier, DigiSoul-Verstärker etc. mit passenden Effekten, Triggern und Tooltips codieren.
+20. [todo] Kartenabhängige Reliktprüfungen integrieren: Sicherstellen, dass Karten nur spielbar sind, wenn alle geforderten Relikte im Besitz sind.
+21. [todo] Starterdeck zusammenstellen: Enthaltene Karten (inkl. Digitationstrigger-Karten) registrieren, Balancing prüfen und Deck-Statistiken dokumentieren.
+22. [todo] Freischalt- und Shop-Kartenlisten konfigurieren: Commons/Uncommons/Rares korrekt verteilen und unlock-/Belohnungslogik definieren.
+23. [todo] Gemeinsame Keyword-Bibliothek erweitern: Neue Keywords (z. B. für Stabilität, DigiSoul) definieren oder bestehende wiederverwenden, Tooltips lokalisiert pflegen.
+24. [todo] Charakterregistrierung vervollständigen: `DigitalesMonster` als spielbaren Charakter mit Farbe, Energieprofil, Animationen (PNG → Spine) und Startrelic(s) anmelden.
+25. [todo] Kampf-Hooks implementieren: Erfolgreiche Angriffe (Spieler/Gegner) verfolgen, Stabilitätswerte aktualisieren und Rückfall-Auslöser handhaben.
+26. [todo] Karten- und Reliktbeschränkungen gegen Plugin-System exportieren: Alle relevanten Klassen/Funktionen über den globalen Plugin-Manager verfügbar machen.
+27. [todo] YAML-Assetmanifest erstellen: Vollständige Liste aller benötigten Texturen (inkl. `inner_card_image`, Stance-PNGs, Relikt-Icons) mit Dateinamen, Pfaden und Auflösungen liefern.
+28. [todo] Dokumentation ergänzen: Mod-spezifische README/How-To aktualisieren, deutsche Kartentext-Richtlinien und Asset-Lieferhinweise festhalten.
+29. [todo] Laufzeitprüfung mit GraalPy durchführen: Aktiviertes Runtime-Backend verifizieren, relevante Startskripte/Bootstrap-Anpassungen dokumentieren.
+30. [todo] Manuelle Smoke-Tests planen und protokollieren: Kernflows (Digitieren, Rückfall, Schwarze Digitation, Digimodify, DigiSoul) durchspielen und Ergebnisse dokumentieren.
+31. [todo] Zukunftserweiterungen in `futures.md` ergänzen: Identifizierte Erweiterungen (z. B. generische Digimon-Level-Frameworks) als langfristige Aufgaben eintragen.

--- a/futures.md
+++ b/futures.md
@@ -229,6 +229,12 @@
   script paths/resources, validates JSON/YAML structure ahead of bundling, and
   publishes a manifest to `PLUGIN_MANAGER` so CI pipelines can diff mechanic
   packs for unexpected mutations.
+- [todo] **Digimon Stance-Balance Telemetrie** – Ergänze das zukünftige
+  Digimon-Level-System um eine optionale Telemetrie, die Stabilitätswerte,
+  Digitationstrigger und Rückfallhäufigkeiten pro Kampf sammelt. Nutzung:
+  Implementiere eine `collect_digimon_metrics()`-Schnittstelle, die Daten an
+  `PLUGIN_MANAGER` broadcastet, damit Balancing-Tools und Analytics-Plugins die
+  Effekte neuer Stances oder Karten bewerten können.
 - [todo] **Adaptive telemetry core visual pass** – Produce production-quality relic art
   and outline textures for the new Adaptive Telemetry Core relic. Usage: create
   high contrast PNGs under `assets/adaptive_evolver/images/relics/` and update

--- a/research/agumon_line_attacks.md
+++ b/research/agumon_line_attacks.md
@@ -1,0 +1,18 @@
+# Agumon Adventure Evolutions – Deutsche Attackennamen
+
+Quelle: https://digimon.fandom.com/de/wiki/Agumon_(Adventure) (abgerufen via Playwright)
+
+| Digimon | Level | Deutsche Attacke | Originalname | Kurzbeschreibung |
+| --- | --- | --- | --- | --- |
+| Koromon | Ausbildung | Seifenblasen | Awa | Spuckt Seifenblasen auf den Gegner. |
+| Agumon | Rookie | Kleine Flamme | Baby Flame | Spuckt einen kleinen Feuerball auf den Gegner. |
+| Greymon | Champion | Megafeuer | Mega Flame | Spuckt einen großen Feuerball. |
+| Greymon | Champion | Großer Hörner Angriff | Great Antler | Rammt Gegner mit Hörnern. |
+| SkullGreymon | Ultra | Atomschuss | Ground Zeromaru | Feuert Rakete vom Rücken. |
+| MetalGreymon | Ultra | Gigaschlag | Giga Destroyer | Feuert zwei organische Raketen aus der Brust. |
+| MetalGreymon | Ultra | Mega-Kralle | Trident Arm | Schießt linke Kralle als Projektil oder direkten Angriff. |
+| WarGreymon | Mega | Planetenkraft | Gaia Force | Bündelt Energie zum Energieball. |
+| WarGreymon | Mega | Megakralle | Great Tornado | Dreht sich zum Wirbelsturm und stürzt sich auf Gegner. |
+| Omnimon | Mega (Jogress) | Gigantisches Schwert | Grey Sword | Schwertangriff. |
+| Omnimon | Mega (Jogress) | Giga-Kanone | Garuru Cannon | Kanonenangriff. |
+| Omnimon Merciful Mode | Mega (Sonder) | Gu-Rei-Tou (Furcht erzitterndes Schwert) | Gu-Rei-Tou | Schwert wird Katana, Mehrfachangriff. |


### PR DESCRIPTION
## Summary
- document binary asset policy in the root authoring guidelines
- add a comprehensive DigitalesMonster development plan with actionable todos
- capture Agumon evolution attack research for German card texts
- extend the futures roadmap with Digimon stance telemetry follow-up work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd30db858883278ff5984bce114d3c