### PR TITLE
Add event-driven overlay triggers and documentation

### DIFF
--- a/futures.md
+++ b/futures.md
@@ -69,6 +69,12 @@
   overlay, tick animations alongside duration tracking, and broadcast progress
   updates through `PLUGIN_MANAGER` so plugins can mirror transitions or extend
   them with custom shaders.
+- [todo] **Overlay trigger diagnostics console** – Build a live inspector that
+  lists registered overlay triggers, highlights their predicates and shows the
+  last payload each trigger consumed. Usage: add `overlay_manager().trigger_map()`
+  and a lightweight CLI/overlay that visualises trigger cooldowns plus recent
+  executions so designers can iterate on automation rules without diving into
+  logs.
 - [todo] **In-process compact loader activation** – Teach the compact bundling
   pipeline to hydrate `.pystsmod` archives directly inside the ModTheSpire
   JVM. Usage: extend the generated loader jar to bootstrap the Python runtime,

--- a/how to/runtime-overlays.md
+++ b/how to/runtime-overlays.md
@@ -58,6 +58,54 @@ All geometry and style properties can be changed via
 handle.update(x=player.drawX + 120, y=player.drawY + 300, rotation=22)
 ```
 
+### Event-driven overlays
+
+Use :func:`modules.basemod_wrapper.overlays.register_overlay_trigger` to spawn or
+update overlays when gameplay hooks fire. The manager currently emits built-in
+events such as ``"card_used"`` and ``"keyword_triggered"`` and any other module
+can call :func:`modules.basemod_wrapper.overlays.handle_overlay_event` to
+publish custom events. Triggers receive the event payload so overlays can adapt
+their appearance dynamically.
+
+```python
+from modules.basemod_wrapper.overlays import register_overlay_trigger
+
+register_overlay_trigger(
+    "card_used",
+    match={"card_id": "Strike_R"},
+    source="assets/ui/strike-flash.png",
+    overlay_kwargs={
+        "x": 1280,
+        "y": 720,
+        "anchor": "center",
+        "duration": 1.5,
+        "metadata": {"source": "Strike_R"},
+    },
+    overlay_identifier="strike_flash",
+)
+
+def keyword_overlay_builder(payload):
+    amount = payload.get("amount", 0)
+    return {
+        "source": "assets/ui/keyword-toast.png",
+        "x": 1640,
+        "y": 960,
+        "metadata": {
+            "keyword": payload.get("keyword_id"),
+            "amount": amount,
+        },
+        "duration": 2.0,
+        "identifier": "keyword_toast",
+    }
+
+register_overlay_trigger(
+    "keyword_triggered",
+    predicate=lambda payload: payload.get("keyword_id") == "flash",
+    builder=keyword_overlay_builder,
+    once=False,
+)
+```
+
 ### Cleaning up
 
 Call `handle.hide()` or `overlay_manager().hide_overlay(identifier)` to remove an

--- a/modules/basemod_wrapper/README.md
+++ b/modules/basemod_wrapper/README.md
@@ -82,6 +82,15 @@ receives an :class:`OverlaySnapshot` alongside the active
 :class:`OverlayManager`, enabling dashboards, telemetry streams or alternative
 UI renderers to stay in sync with the live runtime.
 
+Event-driven automation is available through
+``OverlayManager.register_trigger`` (or the module-level
+``register_overlay_trigger`` helper). Triggers listen for overlay events (for
+example ``"card_used"`` when a card is played or ``"keyword_triggered"`` when a
+keyword fires) and can show, update or hide overlays without manual plumbing.
+Modules and plugins can publish their own events via
+``handle_overlay_event`` which in turn notifies triggers and emits an
+``on_overlay_event`` broadcast for observers.
+
 ## Boot sequence and dependency handling
 
 `ensure_jpype()` is called as soon as the package is imported. Behind the

--- a/research/basemod_OnCardUseSubscriber.java
+++ b/research/basemod_OnCardUseSubscriber.java
@@ -1,0 +1,7 @@
+package basemod.interfaces;
+
+import com.megacrit.cardcrawl.cards.AbstractCard;
+
+public interface OnCardUseSubscriber extends ISubscriber {
+	void receiveCardUsed(AbstractCard c);
+}


### PR DESCRIPTION
## Summary
- add event-driven overlay triggers to the overlay manager, including card event handling and new plugin exports
- emit overlay events from the keyword registry, document trigger usage, and track the follow-up diagnostics work in the futures roadmap
- cover the new trigger behaviour with card and keyword integration tests while recording the BaseMod OnCardUse signature in research

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd42e220c8832792753edd773c067c